### PR TITLE
Aryrabelo created Change Lead Status

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,12 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rdstation-ruby.gemspec
 gemspec
+
+
+group :test do
+  gem 'webmock'
+  gem 'vcr'
+  gem 'turn'
+  gem 'rake'
+  gem 'rspec'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,12 +7,25 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    diff-lcs (1.2.5)
     httparty (0.12.0)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     json (1.8.1)
     multi_xml (0.5.5)
     rake (10.1.0)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.2)
 
 PLATFORMS
   ruby
@@ -21,3 +34,4 @@ DEPENDENCIES
   bundler (~> 1.3)
   rake
   rdstation-ruby-client!
+  rspec

--- a/README.md
+++ b/README.md
@@ -20,12 +20,16 @@ Or install it yourself as:
 
 ### Creating a Lead
     rdstation_client = RDStation::Client.new('rdstation_token', 'auth_token')
-    rdstation_client.create_lead({:email => 'joe@foo.bar', :nome => 'Joe Foo', :empresa => 'A random Company', :cargo => 'Developer'})
+    rdstation_client.create_lead({:email => 'joe@foo.bar', :nome => 'Joe Foo', :empresa => 'A random Company', :cargo => 'Developer', identificador: 'nome_da_conversao'})
 
 ### Changing a Lead
     rdstation_client = RDStation::Client.new('rdstation_token', 'auth_token')
     rdstation_client.change_lead('joe@foo.bar', {:lifecycle_stage => 1, :opportunity => true})
-    
+
+### Change Lead Status
+    rdstation_client = RDStation::Client.new('rdstation_token', 'auth_token')
+    rdstation_client.change_lead_status(email: 'joe@foo.bar', status: 'won', value: 999)
+
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,7 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new
+
+task :default => :spec
+task :test => :spec

--- a/lib/rdstation/client.rb
+++ b/lib/rdstation/client.rb
@@ -46,7 +46,7 @@ module RDStation
     end
     
     def change_lead_status(lead_hash)
-      put_with_body("/services/#{@auth_token}/generic", :body => lead_hash })
+      put_with_body("/services/#{@auth_token}/generic", :body => { lead_hash })
     end
 
   private

--- a/lib/rdstation/client.rb
+++ b/lib/rdstation/client.rb
@@ -44,9 +44,9 @@ module RDStation
       lead_hash = auth_token_hash.merge({:lead => lead_hash})
       put_with_body("/leads/#{lead}", :body => lead_hash.to_json, :headers => {'Content-Type' => 'application/json'})
     end
-    
+
     def change_lead_status(lead_hash)
-      put_with_body("/services/#{@auth_token}/generic", :body => { lead_hash })
+      put_with_body("/services/#{@auth_token}/generic", :body => lead_hash)
     end
 
   private

--- a/lib/rdstation/client.rb
+++ b/lib/rdstation/client.rb
@@ -44,6 +44,10 @@ module RDStation
       lead_hash = auth_token_hash.merge({:lead => lead_hash})
       put_with_body("/leads/#{lead}", :body => lead_hash.to_json, :headers => {'Content-Type' => 'application/json'})
     end
+    
+    def change_lead_status(lead_hash)
+      put_with_body("/services/#{auth_token}/generic", :body => lead_hash.to_json, :headers => {'Content-Type' => 'application/json'})
+    end
 
   private
     def base_url

--- a/lib/rdstation/client.rb
+++ b/lib/rdstation/client.rb
@@ -46,7 +46,7 @@ module RDStation
     end
     
     def change_lead_status(lead_hash)
-      put_with_body("/services/#{@auth_token}/generic", :body => lead_hash.to_json, :headers => {'Content-Type' => 'application/json'})
+      put_with_body("/services/#{@auth_token}/generic", :body => lead_hash })
     end
 
   private

--- a/lib/rdstation/client.rb
+++ b/lib/rdstation/client.rb
@@ -46,7 +46,7 @@ module RDStation
     end
     
     def change_lead_status(lead_hash)
-      put_with_body("/services/#{auth_token}/generic", :body => lead_hash.to_json, :headers => {'Content-Type' => 'application/json'})
+      put_with_body("/services/#{@auth_token}/generic", :body => lead_hash.to_json, :headers => {'Content-Type' => 'application/json'})
     end
 
   private

--- a/rdstation-ruby-client.gemspec
+++ b/rdstation-ruby-client.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'vcr'
 
   spec.add_dependency "httparty", "~> 0.12.0"
 end

--- a/rdstation-ruby-client.gemspec
+++ b/rdstation-ruby-client.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency 'rspec'
 
   spec.add_dependency "httparty", "~> 0.12.0"
 end

--- a/spec/cassettes/change_lead_status.yml
+++ b/spec/cassettes/change_lead_status.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.rdstation.com.br/api/1.2/services/6ec02ba6e8c2534762a537c1a59a3436/generic
+    body:
+      encoding: UTF-8
+      string: email=iginosms%40gmail.com&status=won&value=300
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Server:
+      - nginx
+      Date:
+      - Thu, 29 Jan 2015 18:30:30 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"99914b932bd37a50b983c5e7c90ae93b"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 850b1d42-4d2f-430d-8268-435b36d08c46
+      X-Runtime:
+      - '0.072933'
+      X-Rack-Cache:
+      - invalidate, pass
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 29 Jan 2015 18:30:31 GMT
+recorded_with: VCR 2.9.2

--- a/spec/lib/rdstation-ruby-client_spec.rb
+++ b/spec/lib/rdstation-ruby-client_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe PeriodicTable do
+  it "should return data for a named element" do
+    element_data = PeriodicTable.lookup('oxygen')
+    element_data.should_not be_nil
+    element_data.symbol.should == 'O'
+    element_data.atomic_weight.should == '15.9994'
+  end
+end

--- a/spec/lib/rdstation-ruby-client_spec.rb
+++ b/spec/lib/rdstation-ruby-client_spec.rb
@@ -1,10 +1,26 @@
 require 'spec_helper'
 
-describe PeriodicTable do
-  it "should return data for a named element" do
-    element_data = PeriodicTable.lookup('oxygen')
-    element_data.should_not be_nil
-    element_data.symbol.should == 'O'
-    element_data.atomic_weight.should == '15.9994'
+describe RDStation do
+    let(:rdstation_client) { RDStation::Client.new(ENV['RD_STATION_TOKEN'],
+                                                   ENV['RD_STATION_TOKEN_PRIVATE']) }
+    let(:lead_email) { "iginosms@gmail.com" }
+    let(:amount) { 300}
+
+
+  context "#change_lead_status" do
+    before do
+      VCR.use_cassette('change_lead_status') do
+         @response = rdstation_client.change_lead_status(email: lead_email,  status: 'won', value: amount)
+      end
+    end
+    it 'should see the vars' do
+      expect(lead_email).to_not be_nil
+      expect(amount).to be_a_kind_of(Numeric)
+    end
+    it 'work?' do
+      expect(@response.code).to eql(404)
+    end
+
   end
+
 end

--- a/spec/lib/rdstation-ruby-client_spec.rb
+++ b/spec/lib/rdstation-ruby-client_spec.rb
@@ -18,7 +18,7 @@ describe RDStation do
       expect(amount).to be_a_kind_of(Numeric)
     end
     it 'work?' do
-      expect(@response.code).to eql(404)
+      expect(@response.code).to eql(200)
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,14 @@
 require 'rdstation-ruby-client'
+require 'vcr'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/cassettes'
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
+end
+
+# RSpec.configure do |c|
+#   # so we can use :vcr rather than :vcr => true;
+#   # in RSpec 3 this will no longer be necessary.
+#   c.treat_symbols_as_metadata_keys_with_true_values = true
+# end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'rdstation-ruby-client'


### PR DESCRIPTION
### Change Lead Status
    rdstation_client = RDStation::Client.new('rdstation_token', 'auth_token')
    rdstation_client.change_lead_status(email: 'joe@foo.bar', status: 'won', value: 999)

## Agora é possivel pela gem marcar o lead como ganho ou perdido e fechar venda