### PR TITLE
Update httparty version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rdstation-ruby-client (0.0.2)
-      httparty (>= 0.12.0)
+      httparty (~> 0.12)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rdstation-ruby-client (0.0.2)
-      httparty (~> 0.12.0)
+      httparty (>= 0.12.0)
 
 GEM
   remote: https://rubygems.org/
@@ -12,10 +12,10 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    httparty (0.12.0)
+    httparty (0.13.5)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
-    json (1.8.2)
+    json (1.8.3)
     minitest (4.7.5)
     multi_xml (0.5.5)
     rake (10.1.0)

--- a/rdstation-ruby-client.gemspec
+++ b/rdstation-ruby-client.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'turn'
 
-  spec.add_dependency "httparty", "~> 0.12.0"
+  spec.add_dependency "httparty", ">= 0.12.0"
 end

--- a/rdstation-ruby-client.gemspec
+++ b/rdstation-ruby-client.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'turn'
 
-  spec.add_dependency "httparty", ">= 0.12.0"
+  spec.add_dependency "httparty", "~> 0.12"
 end


### PR DESCRIPTION
This PR releases the 'lock' on version '0.12.0' of httparty, allowing those using the gem to update httparty to newer versions.

I'm tempted to update this gem version to '0.0.3' because, even being not probable, update httparty can have side effects. Do you guys think it is necessary? 