### PR TITLE
Handle multiple error formats

### DIFF
--- a/lib/rdstation-ruby-client.rb
+++ b/lib/rdstation-ruby-client.rb
@@ -8,4 +8,5 @@ require 'rdstation/fields'
 
 # Error handling
 require 'rdstation/error'
+require 'rdstation/error/formatter'
 require 'rdstation/error_handler'

--- a/lib/rdstation/error/format.rb
+++ b/lib/rdstation/error/format.rb
@@ -1,0 +1,30 @@
+module RDStation
+  class Error
+    class Format
+      FLAT_HASH = 'FLAT_HASH'.freeze
+      HASH_OF_ARRAYS = 'HASH_OF_ARRAYS'.freeze
+      ARRAY_OF_HASHES = 'ARRAY_OF_HASHES'.freeze
+
+      def initialize(errors)
+        @errors = errors
+      end
+
+      def format
+        return FLAT_HASH if flat_hash?
+        return HASH_OF_ARRAYS if hash_of_arrays?
+        ARRAY_OF_HASHES
+      end
+
+      private
+
+      def flat_hash?
+        return unless @errors.is_a?(Hash)
+        @errors.key?('error_type')
+      end
+
+      def hash_of_arrays?
+        @errors.is_a?(Hash) && @errors.values.all? { |error| error.is_a? Array }
+      end
+    end
+  end
+end

--- a/lib/rdstation/error/formatter.rb
+++ b/lib/rdstation/error/formatter.rb
@@ -1,74 +1,39 @@
+require_relative './format'
+
 module RDStation
   class Error
     class Formatter
-      def initialize(api_response)
-        @api_response = api_response
-        @errors = JSON.parse(@api_response.body)['errors']
-        raise ArgumentError, "'api_response' does not seem to be an error response." unless @errors
+      def initialize(errors)
+        @errors = errors
       end
 
       def to_array
         case error_format.format
-        when Format::FLAT_HASH
+        when RDStation::Error::Format::FLAT_HASH
           from_flat_hash
-        when Format::HASH_OF_ARRAYS
+        when RDStation::Error::Format::HASH_OF_ARRAYS
           from_hash_of_arrays
         else
-          @errors.each_with_object([]) do |error, array_of_errors|
-            array_of_errors.push(error.merge(additional_request_info))
-          end
+          @errors
         end
       end
 
       def from_flat_hash
-        [@errors.merge(additional_request_info)]
+        [@errors]
       end
 
       def from_hash_of_arrays
-        @errors.each_with_object([]) do |attribute_error, array_of_errors|
-          attribute, errors = attribute_error.first, attribute_error.last
-          additional_attributes = { 'path' => "body.#{attribute}" }.merge(additional_request_info)
-          errors = errors.map { |e| e.merge(additional_attributes) }
+        @errors.each_with_object([]) do |errors, array_of_errors|
+          attribute_name = errors.first
+          attribute_errors = errors.last
+          path = { 'path' => "body.#{attribute_name}" }
+          errors = attribute_errors.map { |error| error.merge(path) }
           array_of_errors.push(*errors)
         end
       end
 
       def error_format
-        @error_format ||= Format.new(@errors)
-      end
-
-      def additional_request_info
-        {
-          'headers' => @api_response.headers,
-          'status' => @api_response.code
-        }
-      end
-
-      class Format
-        ARRAY_OF_HASHES = 'ARRAY_OF_HASHES'.freeze
-        FLAT_HASH = 'FLAT_HASH'.freeze
-        HASH_OF_ARRAYS = 'HASH_OF_ARRAYS'.freeze
-
-        def initialize(errors)
-          @errors = errors
-        end
-
-        def format
-          return 'FLAT_HASH' if flat_hash?
-          return 'HASH_OF_ARRAYS' if hash_of_arrays?
-          'ARRAY_OF_HASHES'
-        end
-
-        private
-
-        def flat_hash?
-          return unless @errors.is_a?(Hash)
-          @errors.key?('error_type')
-        end
-
-        def hash_of_arrays?
-          @errors.is_a?(Hash) && @errors.values.all? { |error| error.is_a? Array }
-        end
+        @error_format ||= RDStation::Error::Format.new(@errors)
       end
     end
   end

--- a/lib/rdstation/error/formatter.rb
+++ b/lib/rdstation/error/formatter.rb
@@ -8,31 +8,33 @@ module RDStation
       end
 
       def to_array
-        raise RDStation, 'This is not an error message.' unless @errors
-
-        if flat_errors?
-          return [@errors.merge(additional_request_info)]
-        elsif hash_of_arrays?
-          return @errors.each_with_object([]) do |attribute_error, array_of_errors|
-            attribute, errors = attribute_error.first, attribute_error.last
-            additional_attributes = { 'path' => "body.#{attribute}" }.merge(additional_request_info)
-            errors = errors.map { |e| e.merge(additional_attributes) }
-            array_of_errors.push(*errors)
+        case error_format.format
+        when Format::FLAT_HASH
+          from_flat_hash
+        when Format::HASH_OF_ARRAYS
+          from_hash_of_arrays
+        else
+          @errors.each_with_object([]) do |error, array_of_errors|
+            array_of_errors.push(error.merge(additional_request_info))
           end
         end
+      end
 
-        @errors.each_with_object([]) do |error, array_of_errors|
-          array_of_errors.push(error.merge(additional_request_info))
+      def from_flat_hash
+        [@errors.merge(additional_request_info)]
+      end
+
+      def from_hash_of_arrays
+        @errors.each_with_object([]) do |attribute_error, array_of_errors|
+          attribute, errors = attribute_error.first, attribute_error.last
+          additional_attributes = { 'path' => "body.#{attribute}" }.merge(additional_request_info)
+          errors = errors.map { |e| e.merge(additional_attributes) }
+          array_of_errors.push(*errors)
         end
       end
 
-      def flat_errors?
-        return unless @errors.is_a?(Hash)
-        @errors.key?('error_type')
-      end
-
-      def hash_of_arrays?
-        @errors.is_a?(Hash) && @errors.values.all? { |error| error.is_a? Array }
+      def error_format
+        @error_format ||= Format.new(@errors)
       end
 
       def additional_request_info
@@ -40,6 +42,33 @@ module RDStation
           'headers' => @api_response.headers,
           'status' => @api_response.code
         }
+      end
+
+      class Format
+        ARRAY_OF_HASHES = 'ARRAY_OF_HASHES'.freeze
+        FLAT_HASH = 'FLAT_HASH'.freeze
+        HASH_OF_ARRAYS = 'HASH_OF_ARRAYS'.freeze
+
+        def initialize(errors)
+          @errors = errors
+        end
+
+        def format
+          return 'FLAT_HASH' if flat_hash?
+          return 'HASH_OF_ARRAYS' if hash_of_arrays?
+          'ARRAY_OF_HASHES'
+        end
+
+        private
+
+        def flat_hash?
+          return unless @errors.is_a?(Hash)
+          @errors.key?('error_type')
+        end
+
+        def hash_of_arrays?
+          @errors.is_a?(Hash) && @errors.values.all? { |error| error.is_a? Array }
+        end
       end
     end
   end

--- a/lib/rdstation/error/formatter.rb
+++ b/lib/rdstation/error/formatter.rb
@@ -1,0 +1,46 @@
+module RDStation
+  class Error
+    class Formatter
+      def initialize(api_response)
+        @api_response = api_response
+        @errors = JSON.parse(@api_response.body)['errors']
+        raise ArgumentError, "'api_response' does not seem to be an error response." unless @errors
+      end
+
+      def to_array
+        raise RDStation, 'This is not an error message.' unless @errors
+
+        if flat_errors?
+          return [@errors.merge(additional_request_info)]
+        elsif hash_of_arrays?
+          return @errors.each_with_object([]) do |attribute_error, array_of_errors|
+            attribute, errors = attribute_error.first, attribute_error.last
+            additional_attributes = { 'path' => "body.#{attribute}" }.merge(additional_request_info)
+            errors = errors.map { |e| e.merge(additional_attributes) }
+            array_of_errors.push(*errors)
+          end
+        end
+
+        @errors.each_with_object([]) do |error, array_of_errors|
+          array_of_errors.push(error.merge(additional_request_info))
+        end
+      end
+
+      def flat_errors?
+        return unless @errors.is_a?(Hash)
+        @errors.key?('error_type')
+      end
+
+      def hash_of_arrays?
+        @errors.is_a?(Hash) && @errors.values.all? { |error| error.is_a? Array }
+      end
+
+      def additional_request_info
+        {
+          'headers' => @api_response.headers,
+          'status' => @api_response.code
+        }
+      end
+    end
+  end
+end

--- a/lib/rdstation/error_handler.rb
+++ b/lib/rdstation/error_handler.rb
@@ -23,16 +23,29 @@ module RDStation
     end
 
     def raise_errors
-      errors.each(&:raise_error)
+      error_types.each(&:raise_error)
       # Raise only the exception message when the error is not recognized
-      unrecognized_error = @response['errors']
-      raise unrecognized_error['error_message']
+      raise array_of_errors.first['error_message']
     end
 
     private
 
-    def errors
-      ERROR_TYPES.map { |error| error.new(@response) }
+    attr_reader :response
+
+    def array_of_errors
+      error_formatter.to_array
+    end
+
+    def error_types
+      ERROR_TYPES.map { |error_type| error_type.new(array_of_errors) }
+    end
+
+    def response_errors
+      response['errors']
+    end
+
+    def error_formatter
+      @error_formatter = RDStation::Error::Formatter.new(response_errors)
     end
   end
 end

--- a/spec/lib/rdstation/error/format_spec.rb
+++ b/spec/lib/rdstation/error/format_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+RSpec.describe RDStation::Error::Format do
+  describe '#format' do
+    subject(:error_format) { described_class.new(errors) }
+
+    context 'when receives a flat hash of errors' do
+      let(:errors) do
+        {
+          'error_type' => 'CONFLICTING_FIELD',
+          'error_message' => 'The payload contains an attribute that was used to identify the lead'
+        }
+      end
+
+      it 'returns the FLAT_HASH format' do
+        result = error_format.format
+        expect(result).to eq(RDStation::Error::Format::FLAT_HASH)
+      end
+    end
+
+    context 'when receives a hash of arrays of errors' do
+      let(:errors) do
+        {
+          'name' => [
+            {
+              'error_type' => 'MUST_BE_STRING',
+              'error_message' => 'Name must be string.'
+            }
+          ]
+        }
+      end
+
+      it 'returns the HASH_OF_ARRAYS format' do
+        result = error_format.format
+        expect(result).to eq(RDStation::Error::Format::HASH_OF_ARRAYS)
+      end
+    end
+
+    context 'when receives an array of errors' do
+      let(:errors) do
+        [
+          {
+            'error_type' => 'CANNOT_BE_NULL',
+            'error_message' => 'Cannot be null.',
+            'path' => 'body.client_secret'
+          }
+        ]
+      end
+
+      it 'returns the ARRAY_OF_HASHES format' do
+        result = error_format.format
+        expect(result).to eq(RDStation::Error::Format::ARRAY_OF_HASHES)
+      end
+    end
+  end
+end

--- a/spec/lib/rdstation/error/formatter_spec.rb
+++ b/spec/lib/rdstation/error/formatter_spec.rb
@@ -1,0 +1,130 @@
+require 'spec_helper'
+
+RSpec.describe RDStation::Error::Formatter do
+  describe '#to_array' do
+    context 'when receives a flat hash of errors' do
+      let(:api_response) do
+        OpenStruct.new(
+          code: 400,
+          headers: { 'content-type' => ['application/json; charset=utf-8'] },
+          body: {
+            'errors' => {
+              'error_type' => 'CONFLICTING_FIELD',
+              'error_message' => 'The payload contains an attribute that was used to identify the lead'
+            }
+          }.to_json
+        )
+      end
+
+      let(:error_formatter) { described_class.new(api_response) }
+
+      let(:expected_result) do
+        [
+          {
+            'error_type' => 'CONFLICTING_FIELD',
+            'error_message' => 'The payload contains an attribute that was used to identify the lead',
+            'status' => 400,
+            'headers' => { 'content-type' => ['application/json; charset=utf-8'] }
+          }
+        ]
+      end
+
+      it 'returns an array of errors including the status code and headers' do
+        result = error_formatter.to_array
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'when receives a hash of arrays of errors' do
+      let(:api_response) do
+        OpenStruct.new(
+          code: 400,
+          headers: { 'content-type' => ['application/json; charset=utf-8'] },
+          body: {
+            'errors' => {
+              'name' => [
+                {
+                  'error_type' => 'MUST_BE_STRING',
+                  'error_message' => 'Name must be string.'
+                }
+              ]
+            }
+          }.to_json
+        )
+      end
+
+      let(:error_formatter) { described_class.new(api_response) }
+
+      let(:expected_result) do
+        [
+          {
+            'error_type' => 'MUST_BE_STRING',
+            'error_message' => 'Name must be string.',
+            'path' => 'body.name',
+            'status' => 400,
+            'headers' => { 'content-type' => ['application/json; charset=utf-8'] }
+          }
+        ]
+      end
+
+      it 'returns an array of errors including the status code and headers' do
+        result = error_formatter.to_array
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'when receives an array of errors' do
+      let(:api_response) do
+        OpenStruct.new(
+          code: 400,
+          headers: { 'content-type' => ['application/json; charset=utf-8'] },
+          body: {
+            'errors' =>
+            [
+              {
+                'error_type' => 'CANNOT_BE_NULL',
+                'error_message' => 'Cannot be null.',
+                'path' => 'body.client_secret'
+              }
+            ]
+          }.to_json
+        )
+      end
+
+      let(:error_formatter) { described_class.new(api_response) }
+
+      let(:expected_result) do
+        [
+          {
+            'error_type' => 'CANNOT_BE_NULL',
+            'error_message' => 'Cannot be null.',
+            'path' => 'body.client_secret',
+            'status' => 400,
+            'headers' => { 'content-type' => ['application/json; charset=utf-8'] }
+          }
+        ]
+      end
+
+      it 'returns an array of errors including the status code and headers' do
+        result = error_formatter.to_array
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'when the received response does not contains errors' do
+      let(:api_response) do
+        OpenStruct.new(
+          code: 400,
+          headers: { 'content-type' => ['application/json; charset=utf-8'] },
+          body: { 'name' => 'Contact Name' }.to_json
+        )
+      end
+
+      it 'raises an error' do
+        expect do
+          described_class.new(api_response)
+        end.to raise_error(ArgumentError, "'api_response' does not seem to be an error response.")
+      end
+    end
+  end
+end

--- a/spec/lib/rdstation/error/formatter_spec.rb
+++ b/spec/lib/rdstation/error/formatter_spec.rb
@@ -2,29 +2,27 @@ require 'spec_helper'
 
 RSpec.describe RDStation::Error::Formatter do
   describe '#to_array' do
+    before do
+      allow(RDStation::Error::Format).to receive(:new).and_return(error_format)
+    end
+
     context 'when receives a flat hash of errors' do
-      let(:api_response) do
-        OpenStruct.new(
-          code: 400,
-          headers: { 'content-type' => ['application/json; charset=utf-8'] },
-          body: {
-            'errors' => {
-              'error_type' => 'CONFLICTING_FIELD',
-              'error_message' => 'The payload contains an attribute that was used to identify the lead'
-            }
-          }.to_json
-        )
+      let(:error_format) { instance_double(RDStation::Error::Format, format: RDStation::Error::Format::FLAT_HASH) }
+
+      let(:errors) do
+        {
+          'error_type' => 'CONFLICTING_FIELD',
+          'error_message' => 'The payload contains an attribute that was used to identify the lead'
+        }
       end
 
-      let(:error_formatter) { described_class.new(api_response) }
+      let(:error_formatter) { described_class.new(errors) }
 
       let(:expected_result) do
         [
           {
             'error_type' => 'CONFLICTING_FIELD',
-            'error_message' => 'The payload contains an attribute that was used to identify the lead',
-            'status' => 400,
-            'headers' => { 'content-type' => ['application/json; charset=utf-8'] }
+            'error_message' => 'The payload contains an attribute that was used to identify the lead'
           }
         ]
       end
@@ -36,33 +34,27 @@ RSpec.describe RDStation::Error::Formatter do
     end
 
     context 'when receives a hash of arrays of errors' do
-      let(:api_response) do
-        OpenStruct.new(
-          code: 400,
-          headers: { 'content-type' => ['application/json; charset=utf-8'] },
-          body: {
-            'errors' => {
-              'name' => [
-                {
-                  'error_type' => 'MUST_BE_STRING',
-                  'error_message' => 'Name must be string.'
-                }
-              ]
+      let(:error_format) { instance_double(RDStation::Error::Format, format: RDStation::Error::Format::HASH_OF_ARRAYS) }
+
+      let(:errors) do
+        {
+          'name' => [
+            {
+              'error_type' => 'MUST_BE_STRING',
+              'error_message' => 'Name must be string.'
             }
-          }.to_json
-        )
+          ]
+        }
       end
 
-      let(:error_formatter) { described_class.new(api_response) }
+      let(:error_formatter) { described_class.new(errors) }
 
       let(:expected_result) do
         [
           {
             'error_type' => 'MUST_BE_STRING',
             'error_message' => 'Name must be string.',
-            'path' => 'body.name',
-            'status' => 400,
-            'headers' => { 'content-type' => ['application/json; charset=utf-8'] }
+            'path' => 'body.name'
           }
         ]
       end
@@ -74,33 +66,26 @@ RSpec.describe RDStation::Error::Formatter do
     end
 
     context 'when receives an array of errors' do
-      let(:api_response) do
-        OpenStruct.new(
-          code: 400,
-          headers: { 'content-type' => ['application/json; charset=utf-8'] },
-          body: {
-            'errors' =>
-            [
-              {
-                'error_type' => 'CANNOT_BE_NULL',
-                'error_message' => 'Cannot be null.',
-                'path' => 'body.client_secret'
-              }
-            ]
-          }.to_json
-        )
+      let(:error_format) { instance_double(RDStation::Error::Format, format: RDStation::Error::Format::ARRAY_OF_HASHES) }
+
+      let(:errors) do
+        [
+          {
+            'error_type' => 'CANNOT_BE_NULL',
+            'error_message' => 'Cannot be null.',
+            'path' => 'body.client_secret'
+          }
+        ]
       end
 
-      let(:error_formatter) { described_class.new(api_response) }
+      let(:error_formatter) { described_class.new(errors) }
 
       let(:expected_result) do
         [
           {
             'error_type' => 'CANNOT_BE_NULL',
             'error_message' => 'Cannot be null.',
-            'path' => 'body.client_secret',
-            'status' => 400,
-            'headers' => { 'content-type' => ['application/json; charset=utf-8'] }
+            'path' => 'body.client_secret'
           }
         ]
       end
@@ -108,22 +93,6 @@ RSpec.describe RDStation::Error::Formatter do
       it 'returns an array of errors including the status code and headers' do
         result = error_formatter.to_array
         expect(result).to eq(expected_result)
-      end
-    end
-
-    context 'when the received response does not contains errors' do
-      let(:api_response) do
-        OpenStruct.new(
-          code: 400,
-          headers: { 'content-type' => ['application/json; charset=utf-8'] },
-          body: { 'name' => 'Contact Name' }.to_json
-        )
-      end
-
-      it 'raises an error' do
-        expect do
-          described_class.new(api_response)
-        end.to raise_error(ArgumentError, "'api_response' does not seem to be an error response.")
       end
     end
   end


### PR DESCRIPTION
## The issue

https://github.com/ResultadosDigitais/rdstation-ruby-client/issues/14

In a nutshell, the RD Station API returns the errors in multiple formats and this gem always expects the same format.

This PR adds the capability for handling multiple error types.

### RD Station API error structures

Currently, the RD Station API has 3 error structures.

#### 01. General errors (`FLAT_HASH`)

When the error does not occurs in a specific attribute but in the request at all.

Example

- When you pass the `email` of a contact both as URI param and payload attribute

```json
{
  "errors": {
    "error_type": "CONFLICTING_FIELD",
    "error_message": "The payload contains an attribute that was used to identify the lead"
  }
}
```

#### 02. Attribute errors with attribute_name as error key (`HASH_OF_ARRAYS`)

When the error occurs for a specific attribute, and the attribute name is used as error key.

Example

- Given a request with the attribute `name` as an integer.

```json
{
  "errors": {
      "name": [
          {
              "error_type": "MUST_BE_STRING",
              "error_message": "Name must be string."
          }
      ]
  }
}
```
#### 03. Array of attribute errors (`ARRAY_OF_HASHES`)

When the error occurs for specific attributes, and the errors are grouped within an array.

Example

- Given a request with the attribute `client_secret` as null.

```json
{
  "errors":
  [
    {
      "error_type":"CANNOT_BE_NULL",
      "error_message":"Cannot be null.",
      "path":"body.client_secret"
    }
  ]
}
```