### PR TITLE
Add events client

### DIFF
--- a/lib/rdstation-ruby-client.rb
+++ b/lib/rdstation-ruby-client.rb
@@ -4,6 +4,7 @@ require 'httparty'
 require 'rdstation/authentication'
 require 'rdstation/client'
 require 'rdstation/contacts'
+require 'rdstation/events'
 require 'rdstation/fields'
 
 # Error handling

--- a/lib/rdstation/error.rb
+++ b/lib/rdstation/error.rb
@@ -23,6 +23,7 @@ module RDStation
     class ExpiredAccessToken < Error; end
     class ExpiredCodeGrant < Error; end
     class InvalidCredentials < Error; end
+    class InvalidEventType < Error; end
     class ResourceNotFound < Error; end
     class Unauthorized < Error; end
   end

--- a/lib/rdstation/error/formatter.rb
+++ b/lib/rdstation/error/formatter.rb
@@ -3,27 +3,29 @@ require_relative './format'
 module RDStation
   class Error
     class Formatter
-      def initialize(errors)
-        @errors = errors
+      def initialize(error_response)
+        @error_response = error_response
       end
 
       def to_array
+        return @error_response unless @error_response.is_a?(Hash)
+
         case error_format.format
         when RDStation::Error::Format::FLAT_HASH
-          from_flat_hash
+          return from_flat_hash
         when RDStation::Error::Format::HASH_OF_ARRAYS
-          from_hash_of_arrays
-        else
-          @errors
+          return from_hash_of_arrays
         end
+
+        errors
       end
 
       def from_flat_hash
-        [@errors]
+        [errors]
       end
 
       def from_hash_of_arrays
-        @errors.each_with_object([]) do |errors, array_of_errors|
+        errors.each_with_object([]) do |errors, array_of_errors|
           attribute_name = errors.first
           attribute_errors = errors.last
           path = { 'path' => "body.#{attribute_name}" }
@@ -33,7 +35,11 @@ module RDStation
       end
 
       def error_format
-        @error_format ||= RDStation::Error::Format.new(@errors)
+        @error_format ||= RDStation::Error::Format.new(errors)
+      end
+
+      def errors
+        @errors ||= @error_response['errors']
       end
     end
   end

--- a/lib/rdstation/error_handler.rb
+++ b/lib/rdstation/error_handler.rb
@@ -4,6 +4,7 @@ require_relative 'error_handler/default'
 require_relative 'error_handler/expired_access_token'
 require_relative 'error_handler/expired_code_grant'
 require_relative 'error_handler/invalid_credentials'
+require_relative 'error_handler/invalid_event_type'
 require_relative 'error_handler/resource_not_found'
 require_relative 'error_handler/unauthorized'
 
@@ -14,6 +15,7 @@ module RDStation
       ErrorHandler::ExpiredAccessToken,
       ErrorHandler::ExpiredCodeGrant,
       ErrorHandler::InvalidCredentials,
+      ErrorHandler::InvalidEventType,
       ErrorHandler::ResourceNotFound,
       ErrorHandler::Unauthorized,
       ErrorHandler::Default

--- a/lib/rdstation/error_handler.rb
+++ b/lib/rdstation/error_handler.rb
@@ -42,7 +42,7 @@ module RDStation
     end
 
     def response_errors
-      JSON.parse(response.body)['errors']
+      JSON.parse(response.body)
     end
 
     def error_formatter

--- a/lib/rdstation/error_handler/invalid_event_type.rb
+++ b/lib/rdstation/error_handler/invalid_event_type.rb
@@ -1,0 +1,27 @@
+module RDStation
+  class ErrorHandler
+    class InvalidEventType
+      attr_reader :errors
+
+      ERROR_CODE = 'INVALID_OPTION'.freeze
+      PATH = '$.event_type'.freeze
+
+      def initialize(errors)
+        @errors = errors
+      end
+
+      def raise_error
+        return if invalid_event_type_error.empty?
+        raise RDStation::Error::InvalidEventType, invalid_event_type_error.first
+      end
+
+      private
+
+      def invalid_event_type_error
+        errors.select do |error|
+          error.values_at('error_type', 'path') == [ERROR_CODE, PATH]
+        end
+      end
+    end
+  end
+end

--- a/lib/rdstation/events.rb
+++ b/lib/rdstation/events.rb
@@ -11,16 +11,7 @@ module RDStation
     end
 
     def create(payload)
-      # {
-      #   "event_type": "OPPORTUNITY_LOST",
-      #   "event_family":"CDP",
-      #   "payload": {
-      #     "email": "email@email.com",
-      #     "funnel_name": "default",
-      #     "reason":"Lost reason"
-      #   }
-      # }
-      response = self.class.post(EVENTS_ENDPOINT, headers: required_headers)
+      response = self.class.post(EVENTS_ENDPOINT, headers: required_headers, body: payload.to_json)
       response_body = JSON.parse(response.body)
       return response_body unless errors?(response_body)
       RDStation::ErrorHandler.new(response).raise_errors

--- a/lib/rdstation/events.rb
+++ b/lib/rdstation/events.rb
@@ -22,11 +22,15 @@ module RDStation
       # }
       response = self.class.post(EVENTS_ENDPOINT, headers: required_headers)
       response_body = JSON.parse(response.body)
-      return response_body unless response_body['errors']
+      return response_body unless errors?(response_body)
       RDStation::ErrorHandler.new(response).raise_errors
     end
 
     private
+
+    def errors?(response_body)
+      response_body.is_a?(Array) || response_body['errors']
+    end
 
     def required_headers
       {

--- a/lib/rdstation/events.rb
+++ b/lib/rdstation/events.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+module RDStation
+  # More info: https://developers.rdstation.com/pt-BR/reference/contacts
+  class Events
+    include HTTParty
+
+    EVENTS_ENDPOINT = 'https://api.rd.services/platform/events'.freeze
+
+    def initialize(auth_token)
+      @auth_token = auth_token
+    end
+
+    def create(payload)
+      # {
+      #   "event_type": "OPPORTUNITY_LOST",
+      #   "event_family":"CDP",
+      #   "payload": {
+      #     "email": "email@email.com",
+      #     "funnel_name": "default",
+      #     "reason":"Lost reason"
+      #   }
+      # }
+      response = self.class.post(EVENTS_ENDPOINT, headers: required_headers)
+      response_body = JSON.parse(response.body)
+      return response_body unless response_body['errors']
+      RDStation::ErrorHandler.new(response).raise_errors
+    end
+
+    private
+
+    def required_headers
+      {
+        'Authorization' => "Bearer #{@auth_token}",
+        'Content-Type'  => 'application/json'
+      }
+    end
+  end
+end

--- a/lib/rdstation/version.rb
+++ b/lib/rdstation/version.rb
@@ -1,3 +1,3 @@
 module RDStation
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.1.0'.freeze
 end

--- a/spec/lib/rdstation/error/formatter_spec.rb
+++ b/spec/lib/rdstation/error/formatter_spec.rb
@@ -9,14 +9,16 @@ RSpec.describe RDStation::Error::Formatter do
     context 'when receives a flat hash of errors' do
       let(:error_format) { instance_double(RDStation::Error::Format, format: RDStation::Error::Format::FLAT_HASH) }
 
-      let(:errors) do
+      let(:error_response) do
         {
-          'error_type' => 'CONFLICTING_FIELD',
-          'error_message' => 'The payload contains an attribute that was used to identify the lead'
+          'errors' => {
+            'error_type' => 'CONFLICTING_FIELD',
+            'error_message' => 'The payload contains an attribute that was used to identify the lead'
+          }
         }
       end
 
-      let(:error_formatter) { described_class.new(errors) }
+      let(:error_formatter) { described_class.new(error_response) }
 
       let(:expected_result) do
         [
@@ -27,7 +29,7 @@ RSpec.describe RDStation::Error::Formatter do
         ]
       end
 
-      it 'returns an array of errors including the status code and headers' do
+      it 'returns an array of errors' do
         result = error_formatter.to_array
         expect(result).to eq(expected_result)
       end
@@ -36,18 +38,20 @@ RSpec.describe RDStation::Error::Formatter do
     context 'when receives a hash of arrays of errors' do
       let(:error_format) { instance_double(RDStation::Error::Format, format: RDStation::Error::Format::HASH_OF_ARRAYS) }
 
-      let(:errors) do
+      let(:error_response) do
         {
-          'name' => [
-            {
-              'error_type' => 'MUST_BE_STRING',
-              'error_message' => 'Name must be string.'
-            }
-          ]
+          'errors' => {
+            'name' => [
+              {
+                'error_type' => 'MUST_BE_STRING',
+                'error_message' => 'Name must be string.'
+              }
+            ]
+          }
         }
       end
 
-      let(:error_formatter) { described_class.new(errors) }
+      let(:error_formatter) { described_class.new(error_response) }
 
       let(:expected_result) do
         [
@@ -59,26 +63,28 @@ RSpec.describe RDStation::Error::Formatter do
         ]
       end
 
-      it 'returns an array of errors including the status code and headers' do
+      it 'returns an array of errors' do
         result = error_formatter.to_array
         expect(result).to eq(expected_result)
       end
     end
 
-    context 'when receives an array of errors' do
+    context 'when receives an array of errors inside the "errors" key' do
       let(:error_format) { instance_double(RDStation::Error::Format, format: RDStation::Error::Format::ARRAY_OF_HASHES) }
 
-      let(:errors) do
-        [
-          {
-            'error_type' => 'CANNOT_BE_NULL',
-            'error_message' => 'Cannot be null.',
-            'path' => 'body.client_secret'
-          }
-        ]
+      let(:error_response) do
+        {
+          'errors' => [
+            {
+              'error_type' => 'CANNOT_BE_NULL',
+              'error_message' => 'Cannot be null.',
+              'path' => 'body.client_secret'
+            }
+          ]
+        }
       end
 
-      let(:error_formatter) { described_class.new(errors) }
+      let(:error_formatter) { described_class.new(error_response) }
 
       let(:expected_result) do
         [
@@ -90,7 +96,38 @@ RSpec.describe RDStation::Error::Formatter do
         ]
       end
 
-      it 'returns an array of errors including the status code and headers' do
+      it 'returns an array of errors' do
+        result = error_formatter.to_array
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'when receives a pure array of errors' do
+      let(:error_format) { '' }
+
+      let(:error_response) do
+        [
+          {
+            'error_type' => 'CANNOT_BE_NULL',
+            'error_message' => 'Cannot be null.',
+            'path' => 'body.client_secret'
+          }
+        ]
+      end
+
+      let(:error_formatter) { described_class.new(error_response) }
+
+      let(:expected_result) do
+        [
+          {
+            'error_type' => 'CANNOT_BE_NULL',
+            'error_message' => 'Cannot be null.',
+            'path' => 'body.client_secret'
+          }
+        ]
+      end
+
+      it 'returns an array of errors' do
         result = error_formatter.to_array
         expect(result).to eq(expected_result)
       end

--- a/spec/lib/rdstation/error_handler/invalid_event_type_spec.rb
+++ b/spec/lib/rdstation/error_handler/invalid_event_type_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe RDStation::ErrorHandler::InvalidEventType do
+  describe '#raise_error' do
+    subject(:invalid_event_type_error) { described_class.new(errors) }
+
+    context 'when there is a invalid event type error' do
+      let(:errors) do
+        [
+          {
+            'error_message' => 'Error Message',
+            'error_type' => 'INVALID_OPTION',
+            'path' => '$.event_type'
+          }
+        ]
+      end
+
+      it 'raises an InvalidEventType error' do
+        expect do
+          invalid_event_type_error.raise_error
+        end.to raise_error(RDStation::Error::InvalidEventType, 'Error Message')
+      end
+    end
+
+    context 'when none of the errors are invalid event type errors' do
+      let(:errors) do
+        [
+          {
+            'error_message' => 'Error Message',
+            'error_type' => 'RANDOM_ERROR_TYPE'
+          },
+          {
+            'error_message' => 'Another Error Message',
+            'error_type' => 'ANOTHER_RANDOM_ERROR_TYPE'
+          }
+        ]
+      end
+
+      it 'does not raise an InvalidEventType error' do
+        result = invalid_event_type_error.raise_error
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when there are no errors' do
+      let(:errors) { [] }
+
+      it 'does not raise an InvalidEventType error' do
+        result = invalid_event_type_error.raise_error
+        expect(result).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/rdstation/events_spec.rb
+++ b/spec/lib/rdstation/events_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+
+RSpec.describe RDStation::Events do
+  let(:valid_auth_token) { 'valid_auth_token' }
+  let(:invalid_auth_token) { 'invalid_auth_token' }
+  let(:expired_auth_token) { 'expired_auth_token' }
+
+  let(:event_with_valid_token) { described_class.new(valid_auth_token) }
+  let(:event_with_expired_token) { described_class.new(expired_auth_token) }
+  let(:event_with_invalid_token) { described_class.new(invalid_auth_token) }
+
+  let(:events_endpoint) { 'https://api.rd.services/platform/events' }
+
+  let(:valid_headers) do
+    {
+      'Authorization' => "Bearer #{valid_auth_token}",
+      'Content-Type' => 'application/json'
+    }
+  end
+
+  let(:invalid_token_headers) do
+    {
+      'Authorization' => "Bearer #{invalid_auth_token}",
+      'Content-Type' => 'application/json'
+    }
+  end
+
+  let(:expired_token_headers) do
+    {
+      'Authorization' => "Bearer #{expired_auth_token}",
+      'Content-Type' => 'application/json'
+    }
+  end
+
+  let(:invalid_token_response) do
+    {
+      status: 401,
+      body: {
+        errors: {
+          error_type: 'UNAUTHORIZED',
+          error_message: 'Invalid token.'
+        }
+      }.to_json
+    }
+  end
+
+  let(:expired_token_response) do
+    {
+      status: 401,
+      headers: { 'WWW-Authenticate' => 'Bearer realm="https://api.rd.services/", error="expired_token", error_description="The access token expired"' },
+      body: {
+        errors: {
+          error_type: 'UNAUTHORIZED',
+          error_message: 'Invalid token.'
+        }
+      }.to_json
+    }
+  end
+
+  describe '#create' do
+    let(:event) do
+      {
+        'event_type' => 'OPPORTUNITY_LOST',
+        'event_family' => 'CDP',
+        'payload' => {
+          'email' => 'email@email.com',
+          'funnel_name' => 'default',
+          'reason' => 'Lost reason'
+        }
+      }
+    end
+
+    context 'with a valid auth token' do
+      before do
+        stub_request(:post, events_endpoint)
+          .with(headers: valid_headers)
+          .to_return(status: 200, body: event.to_json)
+      end
+
+      it 'returns the event uuid' do
+        # {"event_uuid":"830eacd4-6859-43b5-82ef-d2989db38604"}
+        response = event_with_valid_token.create(event)
+        expect(response).to eq(event)
+      end
+    end
+
+    context 'with an invalid auth token' do
+      before do
+        stub_request(:post, events_endpoint)
+          .with(headers: invalid_token_headers)
+          .to_return(invalid_token_response)
+      end
+
+      it 'raises an invalid token error' do
+        expect do
+          event_with_invalid_token.create(event)
+        end.to raise_error(RDStation::Error::Unauthorized)
+      end
+    end
+
+    context 'with an expired auth token' do
+      before do
+        stub_request(:post, events_endpoint)
+          .with(headers: expired_token_headers)
+          .to_return(expired_token_response)
+      end
+
+      it 'raises a expired token error' do
+        expect do
+          event_with_expired_token.create(event)
+        end.to raise_error(RDStation::Error::ExpiredAccessToken)
+      end
+    end
+
+    context 'when the event type is incorrect' do
+      # [{"error_type":"INVALID_OPTION","error_message":"Must be one of the valid options.","validation_rules":{"valid_options":["OPPORTUNITY_LOST","EMAIL_DELIVERED","DOUBLE_OPT_IN_EMAIL_CONFIRMED","OPPORTUNITY","CART_ABANDONED_ITEM","FUNNEL_STAGE_CHANGED","MEDIA_PLAYBACK_STOPPED","CONVERSION","MEDIA_PLAYBACK_STARTED","SALE","WORKFLOW_STARTED","EMAIL_SPAM_REPORTED","ORDER_PLACED","EMAIL_SOFT_BOUNCED","CART_ABANDONED","EMAIL_OPENED","EMAIL_DROPPED","EMAIL_HARD_BOUNCED","WORKFLOW_FINISHED","WORKFLOW_CANCELED","EMAIL_CLICKED","ORDER_PLACED_ITEM","CHAT_STARTED","CHAT_FINISHED","EMAIL_UNSUBSCRIBED","PAGE_VISITED","CALL_FINISHED"]},"path":"$.event_type"}]
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the RD Station events client and a new error handler (InvalidEventType).

## How to test

**Setup**

- Generate a valid RD Station API access token.
- Open the ruby console in the gem path: `irb -r rdstation-ruby-client -I ./lib`

## 01. Creating a valid event

```
event = {
  "event_type" =>  "OPPORTUNITY_LOST",
  "event_family" => "CDP",
  "payload" =>  {
    "email" =>  "teste@example.org",
    "funnel_name" =>  "default",
    "reason" => "Via Ruby Client"
  }
}
events_client = RDStation::Events.new(access_token)
events_client.create(event)
```

- [x] The response should be 200 OK
- [x] The event uuid should be returned, in the following format:
`{"event_uuid"=>"614fe2ac-deef-4a0f-9ccc-977ec381c5a6"}`
- [x] The opportunity in RD Station should be marked as lost.

## 02. Creating an event with an invalid type:

```
event = {
  "event_type" =>  "INVALID",
  "event_family" => "CDP",
  "payload" =>  {
    "email" =>  "teste@example.org",
    "funnel_name" =>  "default",
    "reason" => "Via Ruby Client"
  }
}
events_client = RDStation::Events.new(access_token)
events_client.create(event)
```

- [x] An InvalidEventType should be raised.