### PR TITLE
Add webhooks client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rdstation-ruby-client (1.0.1)
+    rdstation-ruby-client (1.2.0)
       httparty (~> 0.12)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,8 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
+    rspec_junit_formatter (0.3.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
     safe_yaml (1.0.4)
     turn (0.9.7)
       ansi
@@ -49,6 +51,7 @@ DEPENDENCIES
   rake
   rdstation-ruby-client!
   rspec
+  rspec_junit_formatter
   turn
   webmock (~> 2.1)
 

--- a/lib/rdstation-ruby-client.rb
+++ b/lib/rdstation-ruby-client.rb
@@ -1,5 +1,8 @@
 require 'httparty'
 
+# API Response handler
+require 'rdstation/api_response'
+
 # API requests
 require 'rdstation/authentication'
 require 'rdstation/client'

--- a/lib/rdstation-ruby-client.rb
+++ b/lib/rdstation-ruby-client.rb
@@ -6,6 +6,7 @@ require 'rdstation/client'
 require 'rdstation/contacts'
 require 'rdstation/events'
 require 'rdstation/fields'
+require 'rdstation/webhooks'
 
 # Error handling
 require 'rdstation/error'

--- a/lib/rdstation/api_response.rb
+++ b/lib/rdstation/api_response.rb
@@ -1,0 +1,9 @@
+module RDStation
+  module ApiResponse
+    def self.build(response)
+      response_body = JSON.parse(response.body)
+      return response_body unless response_body['errors']
+      RDStation::ErrorHandler.new(response).raise_errors
+    end
+  end
+end

--- a/lib/rdstation/authentication.rb
+++ b/lib/rdstation/authentication.rb
@@ -35,9 +35,7 @@ module RDStation
     # or code is invalid.
     def authenticate(code)
       response = post_to_auth_endpoint(code: code)
-      parsed_body = JSON.parse(response.body)
-      return parsed_body unless parsed_body['errors']
-      RDStation::ErrorHandler.new(response).raise_errors
+      ApiResponse.build(response)
     end
 
     #
@@ -46,9 +44,7 @@ module RDStation
     #
     def update_access_token(refresh_token)
       response = post_to_auth_endpoint(refresh_token: refresh_token)
-      parsed_body = JSON.parse(response.body)
-      return parsed_body unless parsed_body['errors']
-      RDStation::ErrorHandler.new(response).raise_errors
+      ApiResponse.build(response)
     end
 
     private

--- a/lib/rdstation/contacts.rb
+++ b/lib/rdstation/contacts.rb
@@ -14,16 +14,12 @@ module RDStation
     #
     def by_uuid(uuid)
       response = self.class.get(base_url(uuid), headers: required_headers)
-      response_body = JSON.parse(response.body)
-      return response_body unless response_body['errors']
-      RDStation::ErrorHandler.new(response).raise_errors
+      ApiResponse.build(response)
     end
 
     def by_email(email)
       response = self.class.get(base_url("email:#{email}"), headers: required_headers)
-      response_body = JSON.parse(response.body)
-      return response_body unless response_body['errors']
-      RDStation::ErrorHandler.new(response).raise_errors
+      ApiResponse.build(response)
     end
 
     # The Contact hash may contain the following parameters:
@@ -39,9 +35,7 @@ module RDStation
     # :tags
     def update(uuid, contact_hash)
       response = self.class.patch(base_url(uuid), :body => contact_hash.to_json, :headers => required_headers)
-      response_body = JSON.parse(response.body)
-      return response_body unless response_body['errors']
-      RDStation::ErrorHandler.new(response).raise_errors
+      ApiResponse.build(response)
     end
 
     #
@@ -55,9 +49,7 @@ module RDStation
     def upsert(identifier, identifier_value, contact_hash)
       path = "#{identifier}:#{identifier_value}"
       response = self.class.patch(base_url(path), body: contact_hash.to_json, headers: required_headers)
-      response_body = JSON.parse(response.body)
-      return response_body unless response_body['errors']
-      RDStation::ErrorHandler.new(response).raise_errors
+      ApiResponse.build(response)
     end
 
     private

--- a/lib/rdstation/events.rb
+++ b/lib/rdstation/events.rb
@@ -1,6 +1,4 @@
-# encoding: utf-8
 module RDStation
-  # More info: https://developers.rdstation.com/pt-BR/reference/contacts
   class Events
     include HTTParty
 

--- a/lib/rdstation/fields.rb
+++ b/lib/rdstation/fields.rb
@@ -12,9 +12,7 @@ module RDStation
 
     def all
       response = self.class.get(BASE_URL, headers: required_headers)
-      response_body = JSON.parse(response.body)
-      return response_body unless response_body['errors']
-      RDStation::ErrorHandler.new(response).raise_errors
+      ApiResponse.build(response)
     end
 
     private

--- a/lib/rdstation/version.rb
+++ b/lib/rdstation/version.rb
@@ -1,3 +1,3 @@
 module RDStation
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/lib/rdstation/webhooks.rb
+++ b/lib/rdstation/webhooks.rb
@@ -20,6 +20,13 @@ module RDStation
       RDStation::ErrorHandler.new(response).raise_errors
     end
 
+    def create(payload)
+      response = self.class.post(base_url, headers: required_headers, body: payload.to_json)
+      response_body = JSON.parse(response.body)
+      return response_body unless response_body['errors']
+      RDStation::ErrorHandler.new(response).raise_errors
+    end
+
     private
 
     def base_url(path = '')

--- a/lib/rdstation/webhooks.rb
+++ b/lib/rdstation/webhooks.rb
@@ -13,6 +13,13 @@ module RDStation
       RDStation::ErrorHandler.new(response).raise_errors
     end
 
+    def by_uuid(uuid)
+      response = self.class.get(base_url(uuid), headers: required_headers)
+      response_body = JSON.parse(response.body)
+      return response_body unless response_body['errors']
+      RDStation::ErrorHandler.new(response).raise_errors
+    end
+
     private
 
     def base_url(path = '')

--- a/lib/rdstation/webhooks.rb
+++ b/lib/rdstation/webhooks.rb
@@ -1,0 +1,26 @@
+module RDStation
+  class Webhooks
+    include HTTParty
+
+    def initialize(auth_token)
+      @auth_token = auth_token
+    end
+
+    def all
+      response = self.class.get(base_url, headers: required_headers)
+      response_body = JSON.parse(response.body)
+      return response_body unless response_body['errors']
+      RDStation::ErrorHandler.new(response).raise_errors
+    end
+
+    private
+
+    def base_url(path = '')
+      "https://api.rd.services/integrations/webhooks/#{path}"
+    end
+
+    def required_headers
+      { 'Authorization' => "Bearer #{@auth_token}", 'Content-Type' => 'application/json' }
+    end
+  end
+end

--- a/lib/rdstation/webhooks.rb
+++ b/lib/rdstation/webhooks.rb
@@ -8,30 +8,22 @@ module RDStation
 
     def all
       response = self.class.get(base_url, headers: required_headers)
-      response_body = JSON.parse(response.body)
-      return response_body unless response_body['errors']
-      RDStation::ErrorHandler.new(response).raise_errors
+      ApiResponse.build(response)
     end
 
     def by_uuid(uuid)
       response = self.class.get(base_url(uuid), headers: required_headers)
-      response_body = JSON.parse(response.body)
-      return response_body unless response_body['errors']
-      RDStation::ErrorHandler.new(response).raise_errors
+      ApiResponse.build(response)
     end
 
     def create(payload)
       response = self.class.post(base_url, headers: required_headers, body: payload.to_json)
-      response_body = JSON.parse(response.body)
-      return response_body unless response_body['errors']
-      RDStation::ErrorHandler.new(response).raise_errors
+      ApiResponse.build(response)
     end
 
     def update(uuid, payload)
       response = self.class.put(base_url(uuid), headers: required_headers, body: payload.to_json)
-      response_body = JSON.parse(response.body)
-      return response_body unless response_body['errors']
-      RDStation::ErrorHandler.new(response).raise_errors
+      ApiResponse.build(response)
     end
 
     def delete(uuid)

--- a/lib/rdstation/webhooks.rb
+++ b/lib/rdstation/webhooks.rb
@@ -34,7 +34,17 @@ module RDStation
       RDStation::ErrorHandler.new(response).raise_errors
     end
 
+    def delete(uuid)
+      response = self.class.delete(base_url(uuid), headers: required_headers)
+      return webhook_deleted_message unless response.body
+      RDStation::ErrorHandler.new(response).raise_errors
+    end
+
     private
+
+    def webhook_deleted_message
+      { message: 'Webhook deleted successfuly!' }
+    end
 
     def base_url(path = '')
       "https://api.rd.services/integrations/webhooks/#{path}"

--- a/lib/rdstation/webhooks.rb
+++ b/lib/rdstation/webhooks.rb
@@ -27,6 +27,13 @@ module RDStation
       RDStation::ErrorHandler.new(response).raise_errors
     end
 
+    def update(uuid, payload)
+      response = self.class.put(base_url(uuid), headers: required_headers, body: payload.to_json)
+      response_body = JSON.parse(response.body)
+      return response_body unless response_body['errors']
+      RDStation::ErrorHandler.new(response).raise_errors
+    end
+
     private
 
     def base_url(path = '')

--- a/spec/lib/rdstation/webhooks_spec.rb
+++ b/spec/lib/rdstation/webhooks_spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+
+RSpec.describe RDStation::Webhooks do
+  let(:valid_auth_token) { 'valid_auth_token' }
+  let(:invalid_auth_token) { 'invalid_auth_token' }
+  let(:expired_auth_token) { 'expired_auth_token' }
+
+  let(:webhook_with_valid_token) { described_class.new(valid_auth_token) }
+  let(:webhook_with_expired_token) { described_class.new(expired_auth_token) }
+  let(:webhook_with_invalid_token) { described_class.new(invalid_auth_token) }
+
+  let(:webhooks_endpoint) { 'https://api.rd.services/integrations/webhooks/' }
+
+  let(:valid_headers) do
+    {
+      'Authorization' => "Bearer #{valid_auth_token}",
+      'Content-Type' => 'application/json'
+    }
+  end
+
+  let(:invalid_token_headers) do
+    {
+      'Authorization' => "Bearer #{invalid_auth_token}",
+      'Content-Type' => 'application/json'
+    }
+  end
+
+  let(:expired_token_headers) do
+    {
+      'Authorization' => "Bearer #{expired_auth_token}",
+      'Content-Type' => 'application/json'
+    }
+  end
+
+  let(:invalid_token_response) do
+    {
+      status: 401,
+      body: {
+        errors: {
+          error_type: 'UNAUTHORIZED',
+          error_message: 'Invalid token.'
+        }
+      }.to_json
+    }
+  end
+
+  let(:expired_token_response) do
+    {
+      status: 401,
+      headers: { 'WWW-Authenticate' => 'Bearer realm="https://api.rd.services/", error="expired_token", error_description="The access token expired"' },
+      body: {
+        errors: {
+          error_type: 'UNAUTHORIZED',
+          error_message: 'Invalid token.'
+        }
+      }.to_json
+    }
+  end
+
+  describe '#all' do
+    context 'with a valid auth token' do
+      let(:webhooks) do
+        {
+          'webhooks' => [
+            {
+              'uuid' => '5408c5a3-4711-4f2e-8d0b-13407a3e30f3',
+              'event_type' => 'WEBHOOK.CONVERTED',
+              'entity_type' => 'CONTACT',
+              'url' => 'http =>//my-url.com',
+              'http_method' => 'POST',
+              'include_relations' => []
+            },
+            {
+              'uuid' => '642d985c-487c-4c53-b9de-2c1223841cae',
+              'event_type' => 'WEBHOOK.MARKED_OPPORTUNITY',
+              'entity_type' => 'CONTACT',
+              'url' => 'http://my-url.com',
+              'http_method' => 'POST',
+              'include_relations' => %w[COMPANY CONTACT_FUNNEL]
+            }
+          ]
+        }
+      end
+
+      before do
+        stub_request(:get, webhooks_endpoint)
+          .with(headers: valid_headers)
+          .to_return(status: 200, body: webhooks.to_json)
+      end
+
+      it 'returns the webhook' do
+        response = webhook_with_valid_token.all
+        expect(response).to eq(webhooks)
+      end
+    end
+
+    context 'with an invalid auth token' do
+      before do
+        stub_request(:get, webhooks_endpoint)
+          .with(headers: invalid_token_headers)
+          .to_return(invalid_token_response)
+      end
+
+      it 'raises an invalid token error' do
+        expect do
+          webhook_with_invalid_token.all
+        end.to raise_error(RDStation::Error::Unauthorized)
+      end
+    end
+
+    context 'with an expired auth token' do
+      before do
+        stub_request(:get, webhooks_endpoint)
+          .with(headers: expired_token_headers)
+          .to_return(expired_token_response)
+      end
+
+      it 'raises a expired token error' do
+        expect do
+          webhook_with_expired_token.all
+        end.to raise_error(RDStation::Error::ExpiredAccessToken)
+      end
+    end
+  end
+end

--- a/spec/lib/rdstation/webhooks_spec.rb
+++ b/spec/lib/rdstation/webhooks_spec.rb
@@ -152,4 +152,20 @@ RSpec.describe RDStation::Webhooks do
       end
     end
   end
+
+  describe '#delete' do
+    let(:uuid) { '5408c5a3-4711-4f2e-8d0b-13407a3e30f3' }
+    let(:webhooks_endpoint_by_uuid) { webhooks_endpoint + uuid }
+
+    context 'when the request is successful' do
+      before do
+        stub_request(:delete, webhooks_endpoint_by_uuid).with(headers: headers).to_return(status: 204)
+      end
+
+      it 'returns the webhook' do
+        response = webhooks_client.delete(uuid)
+        expect(response).to eq(message: 'Webhook deleted successfuly!')
+      end
+    end
+  end
 end

--- a/spec/lib/rdstation/webhooks_spec.rb
+++ b/spec/lib/rdstation/webhooks_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe RDStation::Webhooks do
           'entity_type' => 'CONTACT',
           'url' => 'http =>//my-url.com',
           'http_method' => 'POST',
-          'include_relations' => []
+          'include_relations' => %w[COMPANY CONTACT_FUNNEL]
         }
       end
 
@@ -110,6 +110,45 @@ RSpec.describe RDStation::Webhooks do
       it 'returns the webhook' do
         response = webhooks_client.create(payload)
         expect(response).to eq(webhook)
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:uuid) { '5408c5a3-4711-4f2e-8d0b-13407a3e30f3' }
+    let(:webhooks_endpoint_by_uuid) { webhooks_endpoint + uuid }
+
+    context 'when the request is successful' do
+      let(:new_payload) do
+        {
+          'entity_type' =>  'CONTACT',
+          'event_type' =>  'WEBHOOK.MARKED_OPPORTUNITY',
+          'url' =>  'http://my-new-url.com',
+          'http_method' => 'POST',
+          'include_relations' => %w[CONTACT_FUNNEL]
+        }
+      end
+
+      let(:updated_webhook) do
+        {
+          'uuid' => uuid,
+          'event_type' => 'WEBHOOK.MARKED_OPPORTUNITY',
+          'entity_type' => 'CONTACT',
+          'url' => 'http://my-new-url.com',
+          'http_method' => 'POST',
+          'include_relations' => %w[CONTACT_FUNNEL]
+        }
+      end
+
+      before do
+        stub_request(:put, webhooks_endpoint_by_uuid)
+          .with(headers: headers, body: new_payload.to_json)
+          .to_return(status: 200, body: updated_webhook.to_json)
+      end
+
+      it 'returns the webhook' do
+        response = webhooks_client.update(uuid, new_payload)
+        expect(response).to eq(updated_webhook)
       end
     end
   end

--- a/spec/lib/rdstation/webhooks_spec.rb
+++ b/spec/lib/rdstation/webhooks_spec.rb
@@ -1,64 +1,18 @@
 require 'spec_helper'
 
 RSpec.describe RDStation::Webhooks do
-  let(:valid_auth_token) { 'valid_auth_token' }
-  let(:invalid_auth_token) { 'invalid_auth_token' }
-  let(:expired_auth_token) { 'expired_auth_token' }
-
-  let(:webhook_with_valid_token) { described_class.new(valid_auth_token) }
-  let(:webhook_with_expired_token) { described_class.new(expired_auth_token) }
-  let(:webhook_with_invalid_token) { described_class.new(invalid_auth_token) }
-
+  let(:webhooks_client) { described_class.new('auth_token') }
   let(:webhooks_endpoint) { 'https://api.rd.services/integrations/webhooks/' }
 
-  let(:valid_headers) do
+  let(:headers) do
     {
-      'Authorization' => "Bearer #{valid_auth_token}",
+      'Authorization' => 'Bearer auth_token',
       'Content-Type' => 'application/json'
-    }
-  end
-
-  let(:invalid_token_headers) do
-    {
-      'Authorization' => "Bearer #{invalid_auth_token}",
-      'Content-Type' => 'application/json'
-    }
-  end
-
-  let(:expired_token_headers) do
-    {
-      'Authorization' => "Bearer #{expired_auth_token}",
-      'Content-Type' => 'application/json'
-    }
-  end
-
-  let(:invalid_token_response) do
-    {
-      status: 401,
-      body: {
-        errors: {
-          error_type: 'UNAUTHORIZED',
-          error_message: 'Invalid token.'
-        }
-      }.to_json
-    }
-  end
-
-  let(:expired_token_response) do
-    {
-      status: 401,
-      headers: { 'WWW-Authenticate' => 'Bearer realm="https://api.rd.services/", error="expired_token", error_description="The access token expired"' },
-      body: {
-        errors: {
-          error_type: 'UNAUTHORIZED',
-          error_message: 'Invalid token.'
-        }
-      }.to_json
     }
   end
 
   describe '#all' do
-    context 'with a valid auth token' do
+    context 'when the request is successful' do
       let(:webhooks) do
         {
           'webhooks' => [
@@ -84,41 +38,13 @@ RSpec.describe RDStation::Webhooks do
 
       before do
         stub_request(:get, webhooks_endpoint)
-          .with(headers: valid_headers)
+          .with(headers: headers)
           .to_return(status: 200, body: webhooks.to_json)
       end
 
       it 'returns all webhooks' do
-        response = webhook_with_valid_token.all
+        response = webhooks_client.all
         expect(response).to eq(webhooks)
-      end
-    end
-
-    context 'with an invalid auth token' do
-      before do
-        stub_request(:get, webhooks_endpoint)
-          .with(headers: invalid_token_headers)
-          .to_return(invalid_token_response)
-      end
-
-      it 'raises an invalid token error' do
-        expect do
-          webhook_with_invalid_token.all
-        end.to raise_error(RDStation::Error::Unauthorized)
-      end
-    end
-
-    context 'with an expired auth token' do
-      before do
-        stub_request(:get, webhooks_endpoint)
-          .with(headers: expired_token_headers)
-          .to_return(expired_token_response)
-      end
-
-      it 'raises a expired token error' do
-        expect do
-          webhook_with_expired_token.all
-        end.to raise_error(RDStation::Error::ExpiredAccessToken)
       end
     end
   end
@@ -127,7 +53,7 @@ RSpec.describe RDStation::Webhooks do
     let(:uuid) { '5408c5a3-4711-4f2e-8d0b-13407a3e30f3' }
     let(:webhooks_endpoint_by_uuid) { webhooks_endpoint + uuid }
 
-    context 'with a valid auth token' do
+    context 'when the request is successful' do
       let(:webhook) do
         {
           'uuid' => uuid,
@@ -141,41 +67,49 @@ RSpec.describe RDStation::Webhooks do
 
       before do
         stub_request(:get, webhooks_endpoint_by_uuid)
-          .with(headers: valid_headers)
+          .with(headers: headers)
           .to_return(status: 200, body: webhook.to_json)
       end
 
       it 'returns the webhook' do
-        response = webhook_with_valid_token.by_uuid(uuid)
+        response = webhooks_client.by_uuid(uuid)
         expect(response).to eq(webhook)
       end
     end
+  end
 
-    context 'with an invalid auth token' do
+  describe '#create' do
+    context 'when the request is successful' do
+      let(:payload) do
+        {
+          'entity_type' =>  'CONTACT',
+          'event_type' =>  'WEBHOOK.CONVERTED',
+          'url' =>  'http://my-url.com',
+          'http_method' => 'POST',
+          'include_relations' => %w[COMPANY CONTACT_FUNNEL]
+        }
+      end
+
+      let(:webhook) do
+        {
+          'uuid' => '5408c5a3-4711-4f2e-8d0b-13407a3e30f3',
+          'event_type' => 'WEBHOOK.CONVERTED',
+          'entity_type' => 'CONTACT',
+          'url' => 'http =>//my-url.com',
+          'http_method' => 'POST',
+          'include_relations' => []
+        }
+      end
+
       before do
-        stub_request(:get, webhooks_endpoint_by_uuid)
-          .with(headers: invalid_token_headers)
-          .to_return(invalid_token_response)
+        stub_request(:post, webhooks_endpoint)
+          .with(headers: headers, body: payload.to_json)
+          .to_return(status: 200, body: webhook.to_json)
       end
 
-      it 'raises an invalid token error' do
-        expect do
-          webhook_with_invalid_token.by_uuid(uuid)
-        end.to raise_error(RDStation::Error::Unauthorized)
-      end
-    end
-
-    context 'with an expired auth token' do
-      before do
-        stub_request(:get, webhooks_endpoint_by_uuid)
-          .with(headers: expired_token_headers)
-          .to_return(expired_token_response)
-      end
-
-      it 'raises a expired token error' do
-        expect do
-          webhook_with_expired_token.by_uuid(uuid)
-        end.to raise_error(RDStation::Error::ExpiredAccessToken)
+      it 'returns the webhook' do
+        response = webhooks_client.create(payload)
+        expect(response).to eq(webhook)
       end
     end
   end


### PR DESCRIPTION
This PR adds the RD Station webhooks client

## How to test

**Setup**

- Generate a valid RD Station API access token.
- Open the ruby console in the gem path: `irb -r rdstation-ruby-client -I ./lib`

## 01. Creating a valid webhook

```
payload = {
  'entity_type' =>  'CONTACT',
  'event_type' =>  'WEBHOOK.CONVERTED',
  'url' =>  'http://my-url.com',
  'http_method' => 'POST',
  'include_relations' => %w[COMPANY CONTACT_FUNNEL]
}
webhooks_client = RDStation::Webhooks.new(access_token)
webhooks_client.create(payload)
```

- [x] The response should be 200 OK
- [x] The webhook payload should be returned, along with a webhook uuid
- [x] The webhook should be created in RD Station.

## 02. Retrieving all webhooks

```
webhooks_client = RDStation::Webhooks.new(access_token)
webhooks_client.all
```

- [x] The response should be 200 OK
- [x] All the webhooks should be returned in the following structure:
```ruby
{
  'webhooks' => [
    {
      'uuid' => '5408c5a3-4711-4f2e-8d0b-13407a3e30f3',
      'event_type' => 'WEBHOOK.CONVERTED',
      'entity_type' => 'CONTACT',
      'url' => 'http =>//my-url.com',
      'http_method' => 'POST',
      'include_relations' => []
    },
    {
      'uuid' => '642d985c-487c-4c53-b9de-2c1223841cae',
      'event_type' => 'WEBHOOK.MARKED_OPPORTUNITY',
      'entity_type' => 'CONTACT',
      'url' => 'http://my-url.com',
      'http_method' => 'POST',
      'include_relations' => %w[COMPANY CONTACT_FUNNEL]
    }
  ]
}
```

## 03. Retrieving a webhook by uuid

```
webhooks_client = RDStation::Webhooks.new(access_token)
webhooks_client.by_uuid(UUID)
```

- [x] The response should be 200 OK
- [x] the webhook should be returned in the following structure:
```ruby
{
  'uuid' => uuid,
  'event_type' => 'WEBHOOK.CONVERTED',
  'entity_type' => 'CONTACT',
  'url' => 'http =>//my-url.com',
  'http_method' => 'POST',
  'include_relations' => []
}
```

## 04. Updating a webhook

```
new_payload = {
  'entity_type' =>  'CONTACT',
  'event_type' =>  'WEBHOOK.CONVERTED',
  'url' =>  'http://my-updated-url.com',
  'http_method' => 'POST',
  'include_relations' => %w[COMPANY CONTACT_FUNNEL]
}
webhooks_client = RDStation::Webhooks.new(access_token)
webhooks_client.update(uuid, new_payload)
```

- [x] The response should be 200 OK
- [x] The webhook payload should be returned with the updated attributes
- [x] The webhook should be updated in RD Station.

## 05. Destroying a webhook

```
new_payload = {
  'entity_type' =>  'CONTACT',
  'event_type' =>  'WEBHOOK.CONVERTED',
  'url' =>  'http://my-updated-url.com',
  'http_method' => 'POST',
  'include_relations' => %w[COMPANY CONTACT_FUNNEL]
}
webhooks_client = RDStation::Webhooks.new(access_token)
webhooks_client.delete(uuid)
```

- [x] The response should be 204 No Content
- [x] The response body should be empty
- [x] The webhook should be deleted from RD Station.