### PR TITLE
Add deprecation warnings and bump version to 1.2.1

### DIFF
--- a/lib/rdstation/client.rb
+++ b/lib/rdstation/client.rb
@@ -7,7 +7,7 @@ module RDStation
     include HTTParty
 
     def initialize(rdstation_token, auth_token, identifier="integração")
-      warn "DEPRECATION WARNING: initialize is deprecated and will be removed in version 2.0.0!"
+      warn "DEPRECATION WARNING: all methods in this class has been deprecated because the version 1.x is no longer under active development and will be removed replaced in version 2.0.0. See more details about the new version here: https://developers.rdstation.com/en/overview"
       @identificador = identifier
       @rdstation_token = rdstation_token
       @auth_token = auth_token
@@ -33,7 +33,7 @@ module RDStation
     # "Detalhes do Lead".
     #
     def create_lead(lead_hash)
-      warn "DEPRECATION WARNING: create_lead is deprecated and will be removed in version 2.0.0!"
+      warn "DEPRECATION WARNING: create_lead has been deprecated because the version 1.x is no longer under active development and will be removed replaced in version 2.0.0. See more details about the new version here: https://developers.rdstation.com/en/overview"
       lead_hash = rdstation_token_hash.merge(lead_hash)
       lead_hash = lead_hash.merge(identifier_hash) unless lead_hash.has_key?(:identificador)
       post_with_body("/conversions", {:body => lead_hash})
@@ -52,13 +52,13 @@ module RDStation
     #       true ou false
     #
     def change_lead(lead, lead_hash)
-      warn "DEPRECATION WARNING: change_lead is deprecated and will be removed in version 2.0.0!"
+      warn "DEPRECATION WARNING: change_lead has been deprecated because the version 1.x is no longer under active development and will be removed replaced in version 2.0.0. See more details about the new version here: https://developers.rdstation.com/en/overview"
       lead_hash = auth_token_hash.merge({:lead => lead_hash})
       put_with_body("/leads/#{lead}", :body => lead_hash.to_json, :headers => {'Content-Type' => 'application/json'})
     end
 
     def change_lead_status(lead_hash)
-      warn "DEPRECATION WARNING: change_lead_status is deprecated and will be removed in version 2.0.0!"
+      warn "DEPRECATION WARNING: change_lead_status has been deprecated because the version 1.x is no longer under active development and will be removed replaced in version 2.0.0. See more details about the new version here: https://developers.rdstation.com/en/overview"
       post_with_body("/services/#{@auth_token}/generic", :body => lead_hash )
     end
 

--- a/lib/rdstation/client.rb
+++ b/lib/rdstation/client.rb
@@ -7,7 +7,7 @@ module RDStation
     include HTTParty
 
     def initialize(rdstation_token, auth_token, identifier="integração")
-      warn "DEPRECATION WARNING: all methods in this class has been deprecated because the version 1.x is no longer under active development and will be removed replaced in version 2.0.0. See more details about the new version here: https://developers.rdstation.com/en/overview"
+      warn "DEPRECATION WARNING: all methods in this class has been deprecated because the version 1.x is no longer under active development and will be removed in version 2.0.0. See more details about the new version here: https://developers.rdstation.com/en/overview"
       @identificador = identifier
       @rdstation_token = rdstation_token
       @auth_token = auth_token
@@ -33,7 +33,7 @@ module RDStation
     # "Detalhes do Lead".
     #
     def create_lead(lead_hash)
-      warn "DEPRECATION WARNING: create_lead has been deprecated because the version 1.x is no longer under active development and will be removed replaced in version 2.0.0. See more details about the new version here: https://developers.rdstation.com/en/overview"
+      warn "DEPRECATION WARNING: create_lead has been deprecated because the version 1.x is no longer under active development and will be removed in version 2.0.0. See more details about the new version here: https://developers.rdstation.com/en/overview"
       lead_hash = rdstation_token_hash.merge(lead_hash)
       lead_hash = lead_hash.merge(identifier_hash) unless lead_hash.has_key?(:identificador)
       post_with_body("/conversions", {:body => lead_hash})
@@ -52,13 +52,13 @@ module RDStation
     #       true ou false
     #
     def change_lead(lead, lead_hash)
-      warn "DEPRECATION WARNING: change_lead has been deprecated because the version 1.x is no longer under active development and will be removed replaced in version 2.0.0. See more details about the new version here: https://developers.rdstation.com/en/overview"
+      warn "DEPRECATION WARNING: change_lead has been deprecated because the version 1.x is no longer under active development and will be removed in version 2.0.0. See more details about the new version here: https://developers.rdstation.com/en/overview"
       lead_hash = auth_token_hash.merge({:lead => lead_hash})
       put_with_body("/leads/#{lead}", :body => lead_hash.to_json, :headers => {'Content-Type' => 'application/json'})
     end
 
     def change_lead_status(lead_hash)
-      warn "DEPRECATION WARNING: change_lead_status has been deprecated because the version 1.x is no longer under active development and will be removed replaced in version 2.0.0. See more details about the new version here: https://developers.rdstation.com/en/overview"
+      warn "DEPRECATION WARNING: change_lead_status has been deprecated because the version 1.x is no longer under active development and will be removed in version 2.0.0. See more details about the new version here: https://developers.rdstation.com/en/overview"
       post_with_body("/services/#{@auth_token}/generic", :body => lead_hash )
     end
 

--- a/lib/rdstation/client.rb
+++ b/lib/rdstation/client.rb
@@ -7,7 +7,7 @@ module RDStation
     include HTTParty
 
     def initialize(rdstation_token, auth_token, identifier="integração")
-      warn "DEPRECATION WARNING: inicialize is deprecated."
+      warn "DEPRECATION WARNING: initialize is deprecated."
       @identificador = identifier
       @rdstation_token = rdstation_token
       @auth_token = auth_token

--- a/lib/rdstation/client.rb
+++ b/lib/rdstation/client.rb
@@ -7,6 +7,7 @@ module RDStation
     include HTTParty
 
     def initialize(rdstation_token, auth_token, identifier="integração")
+      warn "DEPRECATION WARNING: inicialize is deprecated."
       @identificador = identifier
       @rdstation_token = rdstation_token
       @auth_token = auth_token
@@ -32,6 +33,7 @@ module RDStation
     # "Detalhes do Lead".
     #
     def create_lead(lead_hash)
+      warn "DEPRECATION WARNING: create_lead is deprecated."
       lead_hash = rdstation_token_hash.merge(lead_hash)
       lead_hash = lead_hash.merge(identifier_hash) unless lead_hash.has_key?(:identificador)
       post_with_body("/conversions", {:body => lead_hash})
@@ -50,11 +52,13 @@ module RDStation
     #       true ou false
     #
     def change_lead(lead, lead_hash)
+      warn "DEPRECATION WARNING: change_lead is deprecated."
       lead_hash = auth_token_hash.merge({:lead => lead_hash})
       put_with_body("/leads/#{lead}", :body => lead_hash.to_json, :headers => {'Content-Type' => 'application/json'})
     end
 
     def change_lead_status(lead_hash)
+      warn "DEPRECATION WARNING: change_lead_status is deprecated."
       post_with_body("/services/#{@auth_token}/generic", :body => lead_hash )
     end
 

--- a/lib/rdstation/client.rb
+++ b/lib/rdstation/client.rb
@@ -7,7 +7,7 @@ module RDStation
     include HTTParty
 
     def initialize(rdstation_token, auth_token, identifier="integração")
-      warn "DEPRECATION WARNING: initialize is deprecated."
+      warn "DEPRECATION WARNING: initialize is deprecated and will be removed in version 2.0.0!"
       @identificador = identifier
       @rdstation_token = rdstation_token
       @auth_token = auth_token
@@ -33,7 +33,7 @@ module RDStation
     # "Detalhes do Lead".
     #
     def create_lead(lead_hash)
-      warn "DEPRECATION WARNING: create_lead is deprecated."
+      warn "DEPRECATION WARNING: create_lead is deprecated and will be removed in version 2.0.0!"
       lead_hash = rdstation_token_hash.merge(lead_hash)
       lead_hash = lead_hash.merge(identifier_hash) unless lead_hash.has_key?(:identificador)
       post_with_body("/conversions", {:body => lead_hash})
@@ -52,13 +52,13 @@ module RDStation
     #       true ou false
     #
     def change_lead(lead, lead_hash)
-      warn "DEPRECATION WARNING: change_lead is deprecated."
+      warn "DEPRECATION WARNING: change_lead is deprecated and will be removed in version 2.0.0!"
       lead_hash = auth_token_hash.merge({:lead => lead_hash})
       put_with_body("/leads/#{lead}", :body => lead_hash.to_json, :headers => {'Content-Type' => 'application/json'})
     end
 
     def change_lead_status(lead_hash)
-      warn "DEPRECATION WARNING: change_lead_status is deprecated."
+      warn "DEPRECATION WARNING: change_lead_status is deprecated and will be removed in version 2.0.0!"
       post_with_body("/services/#{@auth_token}/generic", :body => lead_hash )
     end
 

--- a/lib/rdstation/version.rb
+++ b/lib/rdstation/version.rb
@@ -1,3 +1,3 @@
 module RDStation
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.2.1'.freeze
 end


### PR DESCRIPTION
- Add deprecation warnings to version 1.x.x for all methods from Client class 
- Increase patch version (from 1.2.0 to 1.2.1).
- fixes #26 