### PR TITLE
Remove deprecated error attributes

### DIFF
--- a/lib/rdstation/error.rb
+++ b/lib/rdstation/error.rb
@@ -7,13 +7,6 @@ module RDStation
       message = details['error_message']
       raise ArgumentError, 'The details hash must contain an error message' unless message
 
-      # Those three arguments are kept only for compatibility reasons.
-      # They aren't needed since we can get them directly in the details hash.
-      # Consider removing them when update the major version.
-      @http_status = details['http_status']
-      @headers = details['headers']
-      @body = details['body']
-
       super(message)
     end
 


### PR DESCRIPTION
The following attributes were removed from the structure of the errors:

```
@http_status = details['http_status']	
@headers = details['headers']	
@body = details['body']
```

All these attributes are present in the details hash, so we don't need redundancy there.