### PR TITLE
Fix bug 47 handle html responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+- Fixed a bug in error handling (issue [#47](https://github.com/ResultadosDigitais/rdstation-ruby-client/issues/47))
+
 ## 2.1.0
 
 ### Additions

--- a/lib/rdstation/api_response.rb
+++ b/lib/rdstation/api_response.rb
@@ -1,8 +1,7 @@
 module RDStation
   module ApiResponse
     def self.build(response)
-      response_body = JSON.parse(response.body)
-      return response_body if response.code.between?(200, 299)
+      return JSON.parse(response.body) if response.code.between?(200, 299)
 
       RDStation::ErrorHandler.new(response).raise_error
     end

--- a/lib/rdstation/error_handler.rb
+++ b/lib/rdstation/error_handler.rb
@@ -14,7 +14,7 @@ module RDStation
 
       error_class.new(array_of_errors).raise_error
     rescue JSON::ParserError => error
-      raise error_class, {'error_message' => response.body}
+      raise error_class, { 'error_message' => response.body }
     end
 
     private

--- a/lib/rdstation/error_handler.rb
+++ b/lib/rdstation/error_handler.rb
@@ -13,6 +13,8 @@ module RDStation
       raise error_class, array_of_errors.first if error_class < RDStation::Error
 
       error_class.new(array_of_errors).raise_error
+    rescue JSON::ParserError => error
+      raise error_class, {'error_message' => response.body}
     end
 
     private

--- a/lib/rdstation/version.rb
+++ b/lib/rdstation/version.rb
@@ -1,3 +1,3 @@
 module RDStation
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.1.1'.freeze
 end

--- a/spec/lib/rdstation/api_response_spec.rb
+++ b/spec/lib/rdstation/api_response_spec.rb
@@ -28,12 +28,6 @@ RSpec.describe RDStation::ApiResponse do
     context "when the response body is not JSON-parseable" do
       let(:response) { OpenStruct.new(code: 504, body: '<html><head></head><body></body></html>') }
 
-      it "raises no error" do
-        expect do
-          RDStation::ApiResponse.build(response)
-        end.not_to raise_error
-      end
-
       it_behaves_like 'call_error_handler'
     end
   end

--- a/spec/lib/rdstation/api_response_spec.rb
+++ b/spec/lib/rdstation/api_response_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe RDStation::ApiResponse do
+  describe ".build" do
+    context "when the response HTTP status is 2xx" do
+      let(:response) { OpenStruct.new(code: 200, body: '{}') }
+
+      it "returns the response body" do
+        expect(RDStation::ApiResponse.build(response)).to eq({})
+      end
+    end
+
+    shared_examples_for 'call_error_handler' do
+      it "calls error handler" do
+        error_handler = instance_double(RDStation::ErrorHandler)
+        allow(error_handler).to receive(:raise_error)
+        expect(RDStation::ErrorHandler).to receive(:new).with(response).and_return(error_handler)
+        RDStation::ApiResponse.build(response)
+      end
+    end
+
+    context "when the response is not in the 2xx range" do
+      let(:response) { OpenStruct.new(code: 404, body: '{}') }
+
+      it_behaves_like 'call_error_handler'
+    end
+
+    context "when the response body is not JSON-parseable" do
+      let(:response) { OpenStruct.new(code: 504, body: '<html><head></head><body></body></html>') }
+
+      it "raises no error" do
+        expect do
+          RDStation::ApiResponse.build(response)
+        end.not_to raise_error
+      end
+
+      it_behaves_like 'call_error_handler'
+    end
+  end
+end

--- a/spec/lib/rdstation/error_handler_spec.rb
+++ b/spec/lib/rdstation/error_handler_spec.rb
@@ -158,5 +158,19 @@ RSpec.describe RDStation::ErrorHandler do
         expect { error_handler.raise_error }.to raise_error(RDStation::Error::ServerError, 'Error Message')
       end
     end
+
+    context "when response body is not JSON-parseable" do
+      let(:error_response) do
+        OpenStruct.new(
+          code: 502,
+          headers: { 'error' => 'header' },
+          body: '<html><body>HTML error response</body></html>'
+        )
+      end
+
+      it 'raises the correct error' do
+        expect { error_handler.raise_error }.to raise_error(RDStation::Error::BadGateway, '<html><body>HTML error response</body></html>')
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR closes #47 

In case of an HTML response by the API (which can happen when there is a major outage) the client was trying to parse a HTML as JSON, which resulted in raising `JSON::ParserError`. This made it impossible to know what the actual error is.

The proposed change here is to encapsulate the parse error and raise the correct exception, with the whole html body  as the error message.