### PR TITLE
Add other endpoints in fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,55 @@ client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'ref
 client.fields.all
 ```
 
+#### Create a field
+
+```ruby
+payload = {} # hash representing the payload
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.fields.create payload
+```
+Or you can use the new `RDStation::Builder::Field`
+
+```ruby
+payload = {} # hash representing the payload
+builder = RDStation::Builder::Field.new payload['api_identifier']
+builder.data_type(payload['data_type'])
+builder.presentation_type(payload['presentation_type'])
+builder.name('pt-BR', payload['name'])
+builder.label('pt-BR', payload['label'])
+
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.fields.create builder.build
+```
+
+#### Update a field
+
+```ruby
+payload = {} # hash representing the payload
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.fields.update('FIELD_UUID', payload) 
+```
+Or you can use the new `RDStation::Builder::Field`
+
+```ruby
+payload = {} # hash representing the payload
+builder = RDStation::Builder::Field.new payload['api_identifier']
+builder.data_type(payload['data_type'])
+builder.presentation_type(payload['presentation_type'])
+builder.name('pt-BR', payload['name'])
+builder.label('pt-BR', payload['label'])
+
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.fields.update('FIELD_UUID', builder.build)
+```
+#### Deleting a field
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.fields.delete('FIELD_UUID')
+```
+
+
 ### Webhooks
 
 Webhooks provide the ability to receive real-time data updates about your contact activity.

--- a/lib/rdstation-ruby-client.rb
+++ b/lib/rdstation-ruby-client.rb
@@ -17,3 +17,6 @@ require 'rdstation/webhooks'
 # Error handling
 require 'rdstation/error'
 require 'rdstation/error_handler'
+
+# Builders
+require 'rdstation/builder/field'

--- a/lib/rdstation/builder/field.rb
+++ b/lib/rdstation/builder/field.rb
@@ -33,7 +33,7 @@ module RDStation
         end
 
         @values['presentation_type'] = presentation_type
-        end
+      end
 
       def label(language, label)
         @values['label'] = { language.to_s => label }

--- a/lib/rdstation/builder/field.rb
+++ b/lib/rdstation/builder/field.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module RDStation
+  class Builder
+    # More info: https://developers.rdstation.com/pt-BR/reference/fields#methodPostDetails
+    class Field
+      DATA_TYPES = %w(STRING INTEGER BOOLEAN STRING[]).freeze
+      PRESENTATION_TYPES = %w[TEXT_INPUT TEXT_AREA URL_INPUT PHONE_INPUT
+                              EMAIL_INPUT CHECK_BOX NUMBER_INPUT COMBO_BOX RADIO_
+                              BUTTON MULTIPLE_CHOICE].freeze
+
+      REQUIRED_FIELDS = %w[api_identifier data_type presentation_type label name].freeze
+
+      def initialize(api_identifier)
+        raise 'api_identifier required' unless api_identifier
+
+        @values = {}
+        @values['api_identifier'] = api_identifier
+      end
+
+      def data_type(data_type)
+        raise 'Not valid data_type' unless DATA_TYPES.include? data_type
+
+        @values['data_type'] = data_type
+      end
+
+      def presentation_type(presentation_type)
+        unless PRESENTATION_TYPES.include? presentation_type
+          raise 'Not valid presentation_type'
+        end
+
+        @values['presentation_type'] = presentation_type
+        end
+
+      def label(language, label)
+        @values['label'] = { language.to_s => label }
+      end
+
+      def name(language, name)
+        @values['name'] = { language.to_s => name }
+      end
+
+      def build
+        if REQUIRED_FIELDS.any? { |field| @values[field].nil? }
+          raise 'Required fields are missing'
+        end
+
+        @values
+      end
+    end
+  end
+end

--- a/lib/rdstation/builder/field.rb
+++ b/lib/rdstation/builder/field.rb
@@ -6,27 +6,30 @@ module RDStation
     class Field
       DATA_TYPES = %w(STRING INTEGER BOOLEAN STRING[]).freeze
       PRESENTATION_TYPES = %w[TEXT_INPUT TEXT_AREA URL_INPUT PHONE_INPUT
-                              EMAIL_INPUT CHECK_BOX NUMBER_INPUT COMBO_BOX RADIO_
-                              BUTTON MULTIPLE_CHOICE].freeze
+                              EMAIL_INPUT CHECK_BOX NUMBER_INPUT COMBO_BOX
+                              RADIO_BUTTON MULTIPLE_CHOICE].freeze
 
       REQUIRED_FIELDS = %w[api_identifier data_type presentation_type label name].freeze
 
       def initialize(api_identifier)
         raise 'api_identifier required' unless api_identifier
+        unless valid_identifier(api_identifier)
+          raise 'api_identifier is not in a valid format, need start with "cf_"'
+        end
 
         @values = {}
         @values['api_identifier'] = api_identifier
       end
 
       def data_type(data_type)
-        raise 'Not valid data_type' unless DATA_TYPES.include? data_type
+        raise "Not valid data_type - #{DATA_TYPES}" unless DATA_TYPES.include? data_type
 
         @values['data_type'] = data_type
       end
 
       def presentation_type(presentation_type)
         unless PRESENTATION_TYPES.include? presentation_type
-          raise 'Not valid presentation_type'
+          raise "Not valid presentation_type - #{PRESENTATION_TYPES}"
         end
 
         @values['presentation_type'] = presentation_type
@@ -40,12 +43,27 @@ module RDStation
         @values['name'] = { language.to_s => name }
       end
 
+      def validation_rules(validation_rules)
+        @values['validation_rules'] = validation_rules
+      end
+
+      def valid_options(valid_options)
+        @values['valid_options'] = valid_options
+      end
+
       def build
-        if REQUIRED_FIELDS.any? { |field| @values[field].nil? }
-          raise 'Required fields are missing'
+        empty_fields = REQUIRED_FIELDS.select { |field| @values[field].nil? }
+        unless empty_fields.empty?
+          raise "Required fields are missing - #{empty_fields}"
         end
 
         @values
+      end
+
+      private
+
+      def valid_identifier(api_identifier)
+        api_identifier.start_with? 'cf_'
       end
     end
   end

--- a/lib/rdstation/error/format.rb
+++ b/lib/rdstation/error/format.rb
@@ -1,9 +1,13 @@
+# frozen_string_literal: true
+
 module RDStation
   class Error
     class Format
-      FLAT_HASH = 'FLAT_HASH'.freeze
-      HASH_OF_ARRAYS = 'HASH_OF_ARRAYS'.freeze
-      ARRAY_OF_HASHES = 'ARRAY_OF_HASHES'.freeze
+      FLAT_HASH = 'FLAT_HASH'
+      HASH_OF_ARRAYS = 'HASH_OF_ARRAYS'
+      ARRAY_OF_HASHES = 'ARRAY_OF_HASHES'
+      HASH_OF_MULTIPLE_TYPES = 'HASH_OF_MULTIPLE_TYPES'
+      HASH_OF_HASHES = 'HASH_OF_HASHES'
 
       def initialize(errors)
         @errors = errors
@@ -12,6 +16,9 @@ module RDStation
       def format
         return FLAT_HASH if flat_hash?
         return HASH_OF_ARRAYS if hash_of_arrays?
+        return HASH_OF_HASHES if hash_of_hashes?
+        return HASH_OF_MULTIPLE_TYPES if hash_of_multiple_types?
+
         ARRAY_OF_HASHES
       end
 
@@ -19,11 +26,22 @@ module RDStation
 
       def flat_hash?
         return unless @errors.is_a?(Hash)
+
         @errors.key?('error_type')
       end
 
       def hash_of_arrays?
         @errors.is_a?(Hash) && @errors.values.all? { |error| error.is_a? Array }
+      end
+
+      def hash_of_hashes?
+        @errors.is_a?(Hash) && @errors.values.all? { |error| error.is_a? Hash }
+      end
+
+      def hash_of_multiple_types?
+        @errors.is_a?(Hash) &&
+          @errors.values.any? { |error| error.is_a? Hash } &&
+          @errors.values.any? { |error| error.is_a? Array }
       end
     end
   end

--- a/lib/rdstation/error/formatter.rb
+++ b/lib/rdstation/error/formatter.rb
@@ -43,7 +43,7 @@ module RDStation
         end
 
         array_of_errors
-        end
+      end
 
       def from_hash_of_hashes
         array_of_errors = []

--- a/lib/rdstation/fields.rb
+++ b/lib/rdstation/fields.rb
@@ -1,12 +1,12 @@
 # encoding: utf-8
 module RDStation
-  # More info: https://developers.rdstation.com/pt-BR/reference/contacts
+  # More info: https://developers.rdstation.com/pt-BR/reference/fields
   class Fields
     include HTTParty
     include ::RDStation::RetryableRequest
 
     BASE_URL = 'https://api.rd.services/platform/contacts/fields'.freeze
-    
+
     def initialize(authorization:)
       @authorization = authorization
     end
@@ -14,6 +14,13 @@ module RDStation
     def all
       retryable_request(@authorization) do |authorization|
         response = self.class.get(BASE_URL, headers: authorization.headers)
+        ApiResponse.build(response)
+      end
+      end
+
+    def create(payload)
+      retryable_request(@authorization) do |authorization|
+        response = self.class.post(BASE_URL, headers: authorization.headers, body: payload.to_json)
         ApiResponse.build(response)
       end
     end

--- a/lib/rdstation/fields.rb
+++ b/lib/rdstation/fields.rb
@@ -25,5 +25,25 @@ module RDStation
       end
     end
 
+    def update(uuid, payload)
+      retryable_request(@authorization) do |authorization|
+        response = self.class.patch(base_url(uuid), headers: authorization.headers, body: payload.to_json)
+        ApiResponse.build(response)
+      end
+    end
+
+    def delete(uuid)
+      retryable_request(@authorization) do |authorization|
+        response = self.class.delete(base_url(uuid), headers: authorization.headers)
+        ApiResponse.build(response)
+      end
+    end
+
+    private
+
+    def base_url(path = '')
+      "#{BASE_URL}/#{path}"
+    end
+
   end
 end

--- a/lib/rdstation/fields.rb
+++ b/lib/rdstation/fields.rb
@@ -16,7 +16,7 @@ module RDStation
         response = self.class.get(BASE_URL, headers: authorization.headers)
         ApiResponse.build(response)
       end
-      end
+    end
 
     def create(payload)
       retryable_request(@authorization) do |authorization|
@@ -44,6 +44,5 @@ module RDStation
     def base_url(path = '')
       "#{BASE_URL}/#{path}"
     end
-
   end
 end

--- a/spec/lib/rdstation/builder/field_spec.rb
+++ b/spec/lib/rdstation/builder/field_spec.rb
@@ -3,31 +3,66 @@
 require 'spec_helper'
 
 RSpec.describe RDStation::Builder::Field do
-  context 'when create a builder' do
-    let(:initial_parameters) do
-      'api_identifier'
+  def valid_builder
+    described_class.new('cf_identifier')
+  end
+
+  describe 'when create a builder' do
+    context 'valid' do
+      let(:initial_parameters) do
+        'cf_api_identifier'
+      end
+
+      let(:builder) { described_class.new(initial_parameters) }
+
+      let(:expected_result) do
+        {
+          'api_identifier' => 'cf_api_identifier',
+          'data_type' => 'STRING',
+          'presentation_type' => 'TEXT_INPUT',
+          'label' => { 'pt-BR' => 'My label' },
+          'name' => { 'pt-BR' => 'My name' }
+        }
+      end
+
+      it 'returns an hash of required values' do
+        builder.label 'pt-BR', 'My label'
+        builder.name 'pt-BR', 'My name'
+        builder.data_type 'STRING'
+        builder.presentation_type 'TEXT_INPUT'
+
+        result = builder.build
+        expect(result).to eq(expected_result)
+      end
     end
+    context 'invalid' do
+      it 'using invalid api_identifier ' do
+        expect { described_class.new('identifier') }.to raise_error(
+          'api_identifier is not in a valid format, need start with "cf_"'
+        )
+      end
 
-    let(:builder) { described_class.new(initial_parameters) }
+      it 'using invalid data_type ' do
+        expect { valid_builder.data_type('type') }.to raise_error(
+          'Not valid data_type - ["STRING", "INTEGER", "BOOLEAN", "STRING[]"]'
+        )
+      end
 
-    let(:expected_result) do
-      {
-        'api_identifier' => 'api_identifier',
-        'data_type' => 'STRING',
-        'presentation_type' => 'TEXT_INPUT',
-        'label' => { 'pt-BR' => 'My label' },
-        'name' => { 'pt-BR' => 'My name' }
-      }
-    end
+      it 'using invalid presentation_type ' do
+        expect { valid_builder.presentation_type('type') }.to raise_error(
+          'Not valid presentation_type - ["TEXT_INPUT", "TEXT_AREA", "URL_INPUT", "PHONE_INPUT", "EMAIL_INPUT", "CHECK_BOX", "NUMBER_INPUT", "COMBO_BOX", "RADIO_BUTTON", "MULTIPLE_CHOICE"]'
+        )
+      end
 
-    it 'returns an hash of required values' do
-      builder.label 'pt-BR', 'My label'
-      builder.name 'pt-BR', 'My name'
-      builder.data_type 'STRING'
-      builder.presentation_type 'TEXT_INPUT'
+      it 'without api_identifier' do
+        expect { described_class.new(nil) }.to raise_error('api_identifier required')
+      end
 
-      result = builder.build
-      expect(result).to eq(expected_result)
+      it 'without required fields' do
+        expect { valid_builder.build }.to raise_error(
+          'Required fields are missing - ["data_type", "presentation_type", "label", "name"]'
+        )
+      end
     end
   end
 end

--- a/spec/lib/rdstation/builder/field_spec.rb
+++ b/spec/lib/rdstation/builder/field_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RDStation::Builder::Field do
+  context 'when create a builder' do
+    let(:initial_parameters) do
+      'api_identifier'
+    end
+
+    let(:builder) { described_class.new(initial_parameters) }
+
+    let(:expected_result) do
+      {
+        'api_identifier' => 'api_identifier',
+        'data_type' => 'STRING',
+        'presentation_type' => 'TEXT_INPUT',
+        'label' => { 'pt-BR' => 'My label' },
+        'name' => { 'pt-BR' => 'My name' }
+      }
+    end
+
+    it 'returns an hash of required values' do
+      builder.label 'pt-BR', 'My label'
+      builder.name 'pt-BR', 'My name'
+      builder.data_type 'STRING'
+      builder.presentation_type 'TEXT_INPUT'
+
+      result = builder.build
+      expect(result).to eq(expected_result)
+    end
+  end
+end

--- a/spec/lib/rdstation/builder/field_spec.rb
+++ b/spec/lib/rdstation/builder/field_spec.rb
@@ -35,21 +35,22 @@ RSpec.describe RDStation::Builder::Field do
         expect(result).to eq(expected_result)
       end
     end
+    
     context 'invalid' do
       it 'using invalid api_identifier ' do
-        expect { described_class.new('identifier') }.to raise_error(
+        expect { described_class.new('invald_identifier') }.to raise_error(
           'api_identifier is not in a valid format, need start with "cf_"'
         )
       end
 
       it 'using invalid data_type ' do
-        expect { valid_builder.data_type('type') }.to raise_error(
+        expect { valid_builder.data_type('invalid_data_type') }.to raise_error(
           'Not valid data_type - ["STRING", "INTEGER", "BOOLEAN", "STRING[]"]'
         )
       end
 
       it 'using invalid presentation_type ' do
-        expect { valid_builder.presentation_type('type') }.to raise_error(
+        expect { valid_builder.presentation_type('invalid presentation_type') }.to raise_error(
           'Not valid presentation_type - ["TEXT_INPUT", "TEXT_AREA", "URL_INPUT", "PHONE_INPUT", "EMAIL_INPUT", "CHECK_BOX", "NUMBER_INPUT", "COMBO_BOX", "RADIO_BUTTON", "MULTIPLE_CHOICE"]'
         )
       end

--- a/spec/lib/rdstation/error/format_spec.rb
+++ b/spec/lib/rdstation/error/format_spec.rb
@@ -52,5 +52,51 @@ RSpec.describe RDStation::Error::Format do
         expect(result).to eq(RDStation::Error::Format::ARRAY_OF_HASHES)
       end
     end
+
+    context 'when receives a mixed type of errors' do
+      let(:errors) do
+        {
+          'label': {
+            'pt-BR': [
+              {
+                'error_type': 'CANNOT_BE_BLANK',
+                'error_message': 'cannot be blank'
+              }
+            ]
+          },
+          'api_identifier': [
+            {
+              'error_type': 'CANNOT_BE_BLANK',
+              'error_message': 'cannot be blank'
+            }
+          ]
+        }
+      end
+
+      it 'returns the HASH_OF_MULTIPLE_TYPES format' do
+        result = error_format.format
+        expect(result).to eq(RDStation::Error::Format::HASH_OF_MULTIPLE_TYPES)
+      end
+    end
+
+    context 'when receives a hash of hashes errors' do
+      let(:errors) do
+        {
+          label: {
+            'pt-BR': [
+              {
+                'error_type': 'CANNOT_BE_BLANK',
+                'error_message': 'cannot be blank'
+              }
+            ]
+          }
+        }
+      end
+
+      it 'returns the HASH_OF_MULTILINGUAL format' do
+        result = error_format.format
+        expect(result).to eq(RDStation::Error::Format::HASH_OF_HASHES)
+      end
+    end
   end
 end

--- a/spec/lib/rdstation/error/formatter_spec.rb
+++ b/spec/lib/rdstation/error/formatter_spec.rb
@@ -132,5 +132,88 @@ RSpec.describe RDStation::Error::Formatter do
         expect(result).to eq(expected_result)
       end
     end
+
+    context 'when receives a hash of multiple type errors' do
+      let(:error_format) { instance_double(RDStation::Error::Format, format: RDStation::Error::Format::HASH_OF_MULTIPLE_TYPES) }
+
+      let(:error_response) do
+        {
+          'errors' => {
+            'label' => {
+              'pt-BR' => [
+                {
+                  'error_type' => 'CANNOT_BE_BLANK',
+                  'error_message' => 'cannot be blank'
+                }
+              ]
+            },
+            'api_identifier' => [
+              {
+                'error_type' => 'CANNOT_BE_BLANK',
+                'error_message' => 'cannot be blank'
+              }
+            ]
+          }
+        }
+      end
+
+      let(:error_formatter) { described_class.new(error_response) }
+
+      let(:expected_result) do
+        [
+          {
+            'error_type' => 'CANNOT_BE_BLANK',
+            'error_message' => 'cannot be blank',
+            'path' => 'body.label.pt-BR'
+          },
+          {
+            'error_type' => 'CANNOT_BE_BLANK',
+            'error_message' => 'cannot be blank',
+            'path' => 'body.api_identifier'
+          }
+        ]
+      end
+
+      it 'returns an array of errors' do
+        result = error_formatter.to_array
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'when receives a hash of hashes type errors' do
+      let(:error_format) { instance_double(RDStation::Error::Format, format: RDStation::Error::Format::HASH_OF_HASHES) }
+
+      let(:error_response) do
+        {
+          'errors' => {
+            'label' => {
+              'pt-BR' => [
+                {
+                  'error_type' => 'CANNOT_BE_BLANK',
+                  'error_message' => 'cannot be blank'
+                }
+              ]
+            }
+          }
+        }
+      end
+
+      let(:error_formatter) { described_class.new(error_response) }
+
+      let(:expected_result) do
+        [
+          {
+            'error_type' => 'CANNOT_BE_BLANK',
+            'error_message' => 'cannot be blank',
+            'path' => 'body.label.pt-BR'
+          }
+        ]
+      end
+
+      it 'returns an array of errors' do
+        result = error_formatter.to_array
+        expect(result).to eq(expected_result)
+      end
+    end
   end
 end


### PR DESCRIPTION
A ideia aqui é contemplar a issue #29 
Métodos adicionados:
- Create
- Update 
- Delete

Além disso, adicionei um Builder para facilitar na hora de criar o Field (update e create), acredito que isso vai ajudar.

Outro detalhe importante, eu precisei adicionar novos detalhes ao tratamento de erros devido a nova API. Isso pode ser visto em `lib/rdstation/error/format.rb` e `lib/rdstation/error/formatter.rb`
Essas classes agora conseguem tratar esse tipo de retorno:
```json
{
  "label": {
    "pt-BR": [
      {
        "error_type": "CANNOT_BE_BLANK",
        "error_message": "cannot be blank"
      }
    ]
  },
  "api_identifier": [
    {
      "error_type": "CANNOT_BE_BLANK",
      "error_message": "cannot be blank"
    }
  ]
}
```
