### PR TITLE
Fix bug 52 rasing a unknown error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1
+
+- Fixed a bug when no error is found in the known errors list (issue [#52](https://github.com/ResultadosDigitais/rdstation-ruby-client/issues/52))
+
 ## 2.3.0
 
 ### Additions

--- a/lib/rdstation/error.rb
+++ b/lib/rdstation/error.rb
@@ -24,6 +24,7 @@ module RDStation
     class BadGateway < Error; end
     class ServiceUnavailable < Error; end
     class ServerError < Error; end
+    class UnknownError < Error; end
 
     # 400 - Bad Request
     class ConflictingField < BadRequest; end

--- a/lib/rdstation/error_handler.rb
+++ b/lib/rdstation/error_handler.rb
@@ -37,6 +37,8 @@ module RDStation
       when 502      then RDStation::Error::BadGateway
       when 503      then RDStation::Error::ServiceUnavailable
       when 500..599 then RDStation::Error::ServerError
+      else
+        RDStation::Error::UnknownError
       end
     end
 

--- a/lib/rdstation/version.rb
+++ b/lib/rdstation/version.rb
@@ -1,3 +1,3 @@
 module RDStation
-  VERSION = '2.3.0'.freeze
+  VERSION = '2.3.1'.freeze
 end

--- a/spec/lib/rdstation/error_handler_spec.rb
+++ b/spec/lib/rdstation/error_handler_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe RDStation::ErrorHandler do
         expect { error_handler.raise_error }.to raise_error(RDStation::Error::ServiceUnavailable, 'Error Message')
       end
     end
+
     context 'with 5xx error' do
       let(:http_status) { 505 }
 
@@ -170,6 +171,14 @@ RSpec.describe RDStation::ErrorHandler do
 
       it 'raises the correct error' do
         expect { error_handler.raise_error }.to raise_error(RDStation::Error::BadGateway, '<html><body>HTML error response</body></html>')
+      end
+    end
+
+    context 'with an unknown error' do
+      let(:http_status) { 123 }
+
+      it 'raises a unknown error' do
+        expect { error_handler.raise_error }.to raise_error(RDStation::Error::UnknownError, 'Error Message')
       end
     end
   end


### PR DESCRIPTION
This PR closes #52  

When no error is found in the [known errors list](https://github.com/ResultadosDigitais/rdstation-ruby-client/blob/dcc7c31e822841a0a9e4c73df591dc6fef2ce5a1/lib/rdstation/error_handler.rb#L24) an '`undefined method`' is occurring:

```
NoMethodError: undefined method `<' for nil:NilClass
lib/rdstation/error_handler.rb:13 raise_error
```

Now an `RDStation::Error::UnknownError` will be raised!