### PR TITLE
Add TooManyRequests error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.0
+
+- Add the ToManyRequests errors in case of rate limit exceeded. See [API request limit](https://developers.rdstation.com/en/request-limit) for more details
+
 ## 2.3.1
 
 - Fixed a bug when no error is found in the known errors list (issue [#52](https://github.com/ResultadosDigitais/rdstation-ruby-client/issues/52))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.4.0
 
-- Add the ToManyRequests errors in case of rate limit exceeded. See [API request limit](https://developers.rdstation.com/en/request-limit) for more details
+- Add the TooManyRequests errors in case of rate limit exceeded. See [API request limit](https://developers.rdstation.com/en/request-limit) for more details
 
 ## 2.3.1
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Each endpoint may raise errors accoording to the HTTP response code from RDStati
 - `RDStation::Error::Conflict` (409)
 - `RDStation::Error::UnsupportedMediaType` (415)
 - `RDStation::Error::UnprocessableEntity` (422)
-- `RDStation::Error::ToManyRequests` (429)
+- `RDStation::Error::TooManyRequests` (429)
 - `RDStation::Error::InternalServerError` (500)
 - `RDStation::Error::NotImplemented` (501)
 - `RDStation::Error::BadGateway` (502)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ RDStation.configure do |config|
     # authorization.access_token_expires_in is the time (in seconds for with the token is valid)
     # authorization.access_token is the new token
     # authorization.refresh_token is the existing refresh_token
-    # 
+    #
     # If you are using ActiveRecord, you may want to update the stored access_token, like in the following code:
     MyStoredAuth.where(refresh_token: authorization.refresh_token).update_all(access_token: authorization.access_token)
   end
@@ -232,7 +232,7 @@ client.fields.create builder.build
 ```ruby
 payload = {} # hash representing the payload
 client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
-client.fields.update('FIELD_UUID', payload) 
+client.fields.update('FIELD_UUID', payload)
 ```
 Or you can use the new `RDStation::Builder::Field`
 
@@ -315,6 +315,7 @@ Each endpoint may raise errors accoording to the HTTP response code from RDStati
 - `RDStation::Error::Conflict` (409)
 - `RDStation::Error::UnsupportedMediaType` (415)
 - `RDStation::Error::UnprocessableEntity` (422)
+- `RDStation::Error::ToManyRequests` (429)
 - `RDStation::Error::InternalServerError` (500)
 - `RDStation::Error::NotImplemented` (501)
 - `RDStation::Error::BadGateway` (502)

--- a/lib/rdstation/error.rb
+++ b/lib/rdstation/error.rb
@@ -19,6 +19,7 @@ module RDStation
     class Conflict < Error; end
     class UnsupportedMediaType < Error; end
     class UnprocessableEntity < Error; end
+    class TooManyRequests < Error; end
     class InternalServerError < Error; end
     class NotImplemented < Error; end
     class BadGateway < Error; end

--- a/lib/rdstation/error/format.rb
+++ b/lib/rdstation/error/format.rb
@@ -8,6 +8,7 @@ module RDStation
       ARRAY_OF_HASHES = 'ARRAY_OF_HASHES'
       HASH_OF_MULTIPLE_TYPES = 'HASH_OF_MULTIPLE_TYPES'
       HASH_OF_HASHES = 'HASH_OF_HASHES'
+      SINGLE_HASH = 'SINGLE_HASH'
 
       def initialize(errors)
         @errors = errors
@@ -15,6 +16,7 @@ module RDStation
 
       def format
         return FLAT_HASH if flat_hash?
+        return SINGLE_HASH if single_hash?
         return HASH_OF_ARRAYS if hash_of_arrays?
         return HASH_OF_HASHES if hash_of_hashes?
         return HASH_OF_MULTIPLE_TYPES if hash_of_multiple_types?
@@ -23,6 +25,12 @@ module RDStation
       end
 
       private
+
+      def single_hash?
+        return unless @errors.is_a?(Hash)
+
+        @errors.key?('error')
+      end
 
       def flat_hash?
         return unless @errors.is_a?(Hash)

--- a/lib/rdstation/error/formatter.rb
+++ b/lib/rdstation/error/formatter.rb
@@ -34,7 +34,7 @@ module RDStation
 
         [
           {
-            'error_type' => 'TO_MANY_REQUESTS',
+            'error_type' => 'TOO_MANY_REQUESTS',
             'error_message' => error_message,
             'details' => error_hash
           }

--- a/lib/rdstation/error/formatter.rb
+++ b/lib/rdstation/error/formatter.rb
@@ -13,6 +13,8 @@ module RDStation
         return @error_response unless @error_response.is_a?(Hash)
 
         case error_format.format
+        when RDStation::Error::Format::SINGLE_HASH
+          return from_single_hash
         when RDStation::Error::Format::FLAT_HASH
           return from_flat_hash
         when RDStation::Error::Format::HASH_OF_ARRAYS
@@ -24,6 +26,19 @@ module RDStation
         end
 
         errors
+      end
+
+      def from_single_hash
+        error_hash = @error_response.dup
+        error_message = error_hash.delete('error')
+
+        [
+          {
+            'error_type' => 'TO_MANY_REQUESTS',
+            'error_message' => error_message,
+            'details' => error_hash
+          }
+        ]
       end
 
       def from_flat_hash
@@ -60,7 +75,7 @@ module RDStation
       end
 
       def errors
-        @errors ||= @error_response['errors']
+        @errors ||= @error_response.fetch('errors', @error_response)
       end
 
       private

--- a/lib/rdstation/error_handler.rb
+++ b/lib/rdstation/error_handler.rb
@@ -32,6 +32,7 @@ module RDStation
       when 409      then RDStation::Error::Conflict
       when 415      then RDStation::Error::UnsupportedMediaType
       when 422      then RDStation::Error::UnprocessableEntity
+      when 429      then RDStation::Error::TooManyRequests
       when 500      then RDStation::Error::InternalServerError
       when 501      then RDStation::Error::NotImplemented
       when 502      then RDStation::Error::BadGateway
@@ -57,7 +58,7 @@ module RDStation
     end
 
     def additional_error_attributes
-      {
+      attrs = {
         'headers' => response.headers,
         'body' => JSON.parse(response.body),
         'http_status' => response.code,

--- a/lib/rdstation/version.rb
+++ b/lib/rdstation/version.rb
@@ -1,3 +1,3 @@
 module RDStation
-  VERSION = '2.3.1'.freeze
+  VERSION = '2.4.0'.freeze
 end

--- a/spec/lib/rdstation/error/format_spec.rb
+++ b/spec/lib/rdstation/error/format_spec.rb
@@ -98,5 +98,22 @@ RSpec.describe RDStation::Error::Format do
         expect(result).to eq(RDStation::Error::Format::HASH_OF_HASHES)
       end
     end
+
+    context 'when receives a single hash with error' do
+      let(:errors) do
+        {
+          'error' => "'lead_limiter' rate limit exceeded for 86400 second(s) period for key ...",
+          'max' => 24,
+          'usage' => 55,
+          'remaining_time' => 20745,
+        }
+      end
+
+      it 'returns the SINGLE_HASH format' do
+        result = error_format.format
+        expect(result).to eq(RDStation::Error::Format::SINGLE_HASH)
+      end
+
+    end
   end
 end

--- a/spec/lib/rdstation/error/formatter_spec.rb
+++ b/spec/lib/rdstation/error/formatter_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe RDStation::Error::Formatter do
       let(:expected_result) do
         [
           {
-            'error_type' => 'TO_MANY_REQUESTS',
+            'error_type' => 'TOO_MANY_REQUESTS',
             'error_message' => "'lead_limiter' rate limit exceeded for 86400 second(s) period for key",
             'details' => { 'max' => 24, 'usage' => 55, 'remaining_time' => 20745 }
           }

--- a/spec/lib/rdstation/error/formatter_spec.rb
+++ b/spec/lib/rdstation/error/formatter_spec.rb
@@ -215,5 +215,35 @@ RSpec.describe RDStation::Error::Formatter do
         expect(result).to eq(expected_result)
       end
     end
+
+    context 'when receives a single hash of errors' do
+      let(:error_format) { instance_double(RDStation::Error::Format, format: RDStation::Error::Format::SINGLE_HASH) }
+
+      let(:error_response) do
+        {
+          'error' => "'lead_limiter' rate limit exceeded for 86400 second(s) period for key",
+          'max' => 24,
+          'usage' => 55,
+          'remaining_time' => 20745
+        }
+      end
+
+      let(:error_formatter) { described_class.new(error_response) }
+
+      let(:expected_result) do
+        [
+          {
+            'error_type' => 'TO_MANY_REQUESTS',
+            'error_message' => "'lead_limiter' rate limit exceeded for 86400 second(s) period for key",
+            'details' => { 'max' => 24, 'usage' => 55, 'remaining_time' => 20745 }
+          }
+        ]
+      end
+
+      it 'returns an array of errors' do
+        result = error_formatter.to_array
+        expect(result).to eq(expected_result)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds a new error `Too Many Requests` when  API returns 429 error. 

See [API request limit](https://developers.rdstation.com/en/request-limit) for more details