### PR TITLE
Add InvalidRefreshToken error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.5.0
+
+- InvalidRefreshToken error added. This error will be raised when the refresh token is invalid or it was revoked. When you get this error, you can safely disconnect the user from RD Station.
+
+Usage example:
+
+```ruby
+begin
+  rdstation.update_access_token(refresh_token)
+rescue RDStation::Error::InvalidRefreshToken
+  # Disconnect user
+end
+```
+
 ## 2.4.0
 
 - Add the TooManyRequests errors in case of rate limit exceeded. See [API request limit](https://developers.rdstation.com/en/request-limit) for more details

--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,7 @@ RSpec::Core::RakeTask.new
 
 task :default => :spec
 task :test => :spec
+
+task :console do
+  exec 'pry -r rdstation-ruby-client -I ./lib'
+end

--- a/lib/rdstation/error.rb
+++ b/lib/rdstation/error.rb
@@ -35,5 +35,6 @@ module RDStation
     class ExpiredAccessToken < Unauthorized; end
     class ExpiredCodeGrant < Unauthorized; end
     class InvalidCredentials < Unauthorized; end
+    class InvalidRefreshToken < Unauthorized; end
   end
 end

--- a/lib/rdstation/error_handler/invalid_refresh_token.rb
+++ b/lib/rdstation/error_handler/invalid_refresh_token.rb
@@ -1,0 +1,24 @@
+module RDStation
+  class ErrorHandler
+    class InvalidRefreshToken
+      attr_reader :errors
+
+      ERROR_CODE = 'INVALID_REFRESH_TOKEN'.freeze
+
+      def initialize(errors)
+        @errors = errors
+      end
+
+      def raise_error
+        return if invalid_refresh_token_error.empty?
+        raise RDStation::Error::InvalidRefreshToken, invalid_refresh_token_error.first
+      end
+
+      private
+
+      def invalid_refresh_token_error
+        errors.select { |error| error['error_type'] == ERROR_CODE }
+      end
+    end
+  end
+end

--- a/lib/rdstation/error_handler/invalid_refresh_token.rb
+++ b/lib/rdstation/error_handler/invalid_refresh_token.rb
@@ -11,13 +11,13 @@ module RDStation
 
       def raise_error
         return if invalid_refresh_token_error.empty?
-        raise RDStation::Error::InvalidRefreshToken, invalid_refresh_token_error.first
+        raise RDStation::Error::InvalidRefreshToken, invalid_refresh_token_error
       end
 
       private
 
       def invalid_refresh_token_error
-        errors.select { |error| error['error_type'] == ERROR_CODE }
+        errors.find { |error| error['error_type'] == ERROR_CODE }
       end
     end
   end

--- a/lib/rdstation/error_handler/unauthorized.rb
+++ b/lib/rdstation/error_handler/unauthorized.rb
@@ -1,6 +1,7 @@
 require_relative 'expired_access_token'
 require_relative 'expired_code_grant'
 require_relative 'invalid_credentials'
+require_relative 'invalid_refresh_token'
 
 module RDStation
   class ErrorHandler
@@ -9,6 +10,7 @@ module RDStation
         ErrorHandler::ExpiredAccessToken,
         ErrorHandler::ExpiredCodeGrant,
         ErrorHandler::InvalidCredentials,
+        ErrorHandler::InvalidRefreshToken,
       ].freeze
 
       def initialize(array_of_errors)

--- a/lib/rdstation/version.rb
+++ b/lib/rdstation/version.rb
@@ -1,3 +1,3 @@
 module RDStation
-  VERSION = '2.4.0'.freeze
+  VERSION = '2.5.0'.freeze
 end

--- a/spec/lib/rdstation/authentication_spec.rb
+++ b/spec/lib/rdstation/authentication_spec.rb
@@ -217,19 +217,32 @@ RSpec.describe RDStation::Authentication do
     end
 
     context 'when the refresh token is invalid' do
+      let(:invalid_refresh_token_response) do
+        {
+          status: 401,
+          headers: { 'Content-Type' => 'application/json' },
+          body: {
+            errors: {
+              error_type: 'INVALID_REFRESH_TOKEN',
+              error_message: 'The provided refresh token is invalid or was revoked.'
+            }
+          }.to_json
+        }
+      end
+
       before do
         stub_request(:post, token_endpoint)
           .with(
             headers: request_headers,
             body: token_request_with_invalid_refresh_token.to_json
           )
-          .to_return(invalid_code_response)
+          .to_return(invalid_refresh_token_response)
       end
 
       it 'returns an auth error' do
         expect do
           authentication.update_access_token('invalid_refresh_token')
-        end.to raise_error(RDStation::Error::InvalidCredentials)
+        end.to raise_error(RDStation::Error::InvalidRefreshToken)
       end
     end
 

--- a/spec/lib/rdstation/error_handler/invalid_refresh_token_spec.rb
+++ b/spec/lib/rdstation/error_handler/invalid_refresh_token_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+RSpec.describe RDStation::ErrorHandler::InvalidRefreshToken do
+  describe '#raise_error' do
+    subject(:invalid_refresh_token) { described_class.new(errors) }
+
+    context 'when the refresh token is invalid or was revoked' do
+      let(:errors) do
+        [
+          {
+            'error_type' => 'INVALID_REFRESH_TOKEN',
+            'error_message' => 'Error Message',
+          }
+        ]
+      end
+
+      it 'raises an InvalidRefreshToken error' do
+        expect do
+          invalid_refresh_token.raise_error
+        end.to raise_error(RDStation::Error::InvalidRefreshToken, 'Error Message')
+      end
+    end
+
+    context 'when none of the errors are invalid refresh token errors' do
+      let(:errors) do
+        [
+          {
+            'error_message' => 'Error Message',
+            'error_type' => 'RANDOM_ERROR_TYPE'
+          },
+          {
+            'error_message' => 'Another Error Message',
+            'error_type' => 'ANOTHER_RANDOM_ERROR_TYPE'
+          }
+        ]
+      end
+
+      it 'does not raise an InvalidRefreshToken error' do
+        result = invalid_refresh_token.raise_error
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when there are no errors' do
+      let(:errors) { [] }
+
+      it 'does not raise an InvalidRefreshToken error' do
+        result = invalid_refresh_token.raise_error
+        expect(result).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new exception: `RDStation::Error::InvalidRefreshToken`.

This exception is raised in the following cases:

- The app revoked the authorization
- The end-user revoked the authorization
- The refresh token is invalid

The usage would be something like this:

```ruby
begin
  rdstation.update_access_token(refresh_token)
rescue RDStation::Error::InvalidRefreshToken
  # Disconnect user from my platform
end
```

## How to test

- Install an app in your RD Station production account
- Open this gem directory and run the console:

```
> gem build rdstation-ruby-client.gemspec
> rake console
```

- In the console, set your credentials up:

```ruby
RDStation.configure do |config|
  config.client_id = CLIENT_ID
  config.client_secret = CLIENT_SECRET
end

refresh_token = MY_REFRESH_TOKEN

rdstation_authentication = RDStation::Authentication.new
```

- Make a request to obtain a new access token:

```ruby
rdstation_authentication.update_access_token(refresh_token)
```

- [x] The response should include the credentials:

```ruby
{
  "access_token"=> ACCESS_TOKEN,
 "expires_in"=>86400,
 "refresh_token"=>REFRESH_TOKEN
}
```

- Delete the app from your account: https://app.rdstation.com.br/integracoes
- Now, repeat the request for a new access token:
```ruby
rdstation_authentication.update_access_token(refresh_token)
```

- [x] It should raise a `RDStation::Error::InvalidRefreshToken` error
