### PR TITLE
Configure base host 

### DIFF
--- a/lib/rdstation.rb
+++ b/lib/rdstation.rb
@@ -2,14 +2,21 @@ module RDStation
   class << self
     attr_accessor :configuration
 
+    HOST = 'https://api.rd.services'.freeze
+
     def configure
       self.configuration ||= Configuration.new
+      self.configuration.base_host = HOST
       yield(configuration)
     end
+
+    def host
+      self.configuration&.base_host || HOST
+    end
   end
-  
+
   class Configuration
-    attr_accessor :client_id, :client_secret
+    attr_accessor :client_id, :client_secret, :base_host
     attr_reader :access_token_refresh_callback
 
     def on_access_token_refresh(&block)

--- a/lib/rdstation/authentication.rb
+++ b/lib/rdstation/authentication.rb
@@ -3,9 +3,9 @@ module RDStation
   class Authentication
     include HTTParty
 
-    AUTH_TOKEN_URL = 'https://api.rd.services/auth/token'.freeze
+    AUTH_TOKEN_URL = "#{RDStation.host}/auth/token".freeze
     DEFAULT_HEADERS = { 'Content-Type' => 'application/json' }.freeze
-    REVOKE_URL = 'https://api.rd.services/auth/revoke'.freeze
+    REVOKE_URL = "#{RDStation.host}/auth/revoke".freeze
 
     def initialize(client_id = nil, client_secret = nil)
       warn_deprecation if client_id || client_secret
@@ -19,7 +19,7 @@ module RDStation
     #  after confirming application authorization
     #
     def auth_url(redirect_url)
-      "https://api.rd.services/auth/dialog?client_id=#{@client_id}&redirect_url=#{redirect_url}"
+      "#{RDStation.host}/auth/dialog?client_id=#{@client_id}&redirect_url=#{redirect_url}"
     end
 
     # Public: Get the credentials from RD Station API

--- a/lib/rdstation/contacts.rb
+++ b/lib/rdstation/contacts.rb
@@ -64,7 +64,7 @@ module RDStation
     private
 
     def base_url(path = '')
-      "https://api.rd.services/platform/contacts/#{path}"
+      "#{RDStation.host}/platform/contacts/#{path}"
     end
   end
 end

--- a/lib/rdstation/events.rb
+++ b/lib/rdstation/events.rb
@@ -3,7 +3,7 @@ module RDStation
     include HTTParty
     include ::RDStation::RetryableRequest
 
-    EVENTS_ENDPOINT = 'https://api.rd.services/platform/events'.freeze
+    EVENTS_ENDPOINT = "#{RDStation.host}/platform/events".freeze
 
     def initialize(authorization:)
       @authorization = authorization

--- a/lib/rdstation/fields.rb
+++ b/lib/rdstation/fields.rb
@@ -5,7 +5,7 @@ module RDStation
     include HTTParty
     include ::RDStation::RetryableRequest
 
-    BASE_URL = 'https://api.rd.services/platform/contacts/fields'.freeze
+    BASE_URL = "#{RDStation.host}/platform/contacts/fields".freeze
 
     def initialize(authorization:)
       @authorization = authorization

--- a/lib/rdstation/version.rb
+++ b/lib/rdstation/version.rb
@@ -1,3 +1,3 @@
 module RDStation
-  VERSION = '2.5.1'.freeze
+  VERSION = '2.5.2'.freeze
 end

--- a/lib/rdstation/webhooks.rb
+++ b/lib/rdstation/webhooks.rb
@@ -51,7 +51,7 @@ module RDStation
     end
 
     def base_url(path = '')
-      "https://api.rd.services/integrations/webhooks/#{path}"
+      "#{RDStation.host}/integrations/webhooks/#{path}"
     end
   end
 end

--- a/spec/lib/rdstation_spec.rb
+++ b/spec/lib/rdstation_spec.rb
@@ -1,18 +1,41 @@
 require 'spec_helper'
 
 RSpec.describe RDStation do
+  let(:client_id) { 'client_id' }
+  let(:client_secret) { 'client_secret' }
+  let(:base_host) { 'https://test-api.rd.services' }
+
+  before do
+    RDStation.configure do |config|
+      config.client_id = client_id
+      config.client_secret = client_secret
+      config.base_host = base_host
+    end
+  end
+
+  after { RDStation.configure {} }
+
   describe '.configure' do
-    let(:client_id) { 'client_id' }
-    let(:client_secret) { 'client_secret' }
-
     it 'sets the configuration' do
-      RDStation.configure do |config|
-        config.client_id = client_id
-        config.client_secret = client_secret
-      end
+      expect(RDStation.configuration.client_id).to eq(client_id)
+      expect(RDStation.configuration.client_secret).to eq(client_secret)
+      expect(RDStation.configuration.base_host).to eq(base_host)
+    end
+  end
 
-      expect(RDStation.configuration.client_id).to eq client_id
-      expect(RDStation.configuration.client_secret).to eq client_secret
+  describe '.host' do
+    context 'when base_host is defined in configuration' do
+      it 'returns specified host' do
+        expect(RDStation.host).to eq(base_host)
+      end
+    end
+
+    context 'when base_host is not defined in configuration' do
+      it 'returns default host' do
+        RDStation.configure {}
+
+        expect(RDStation.host).to eq('https://api.rd.services')
+      end
     end
   end
 end


### PR DESCRIPTION
## Why do we need this change?
Currently in RDSCRM staging environment we do not connect to RDSM staging env. This makes harder to test our changes in staging, and by consequence, increases our chances of deploy features with bugs, or with more complexity than needed due the over use of feature flags. This result in a bad user experience and incidents.

We need to connect to a proper staging environment in order to be able to test our features that need to talk with RDSM.

## How will it work?

In order to do that, this PR aims to allow us (the user) to configure the base host, giving us the flexibility that we need to point the calls to a different url than `api.rd.services`.

```ruby
RDStation.configure do |config|
  config.client_id = client_id
  config.client_secret = client_secret
  config.base_host = 'https://my-staging-host'
end
```

## Will these changes break my app?

No. While developing this, we noticed the use of `&` safe navigators in configurations, so we tried to let it as it is and ensured it will not break if we do not pass this config.

```ruby
def host
  self.configuration&.base_host || HOST
end
```    

It is important to emphasize that this is not a mandatory config, if it is not present, the gem will keep its expected behaviour.
This means that it not given, the base host will not be changed.  