### PR TITLE
Remove constants to allow RDStation.host to setup properly the url

### DIFF
--- a/lib/rdstation/authentication.rb
+++ b/lib/rdstation/authentication.rb
@@ -3,9 +3,7 @@ module RDStation
   class Authentication
     include HTTParty
 
-    AUTH_TOKEN_URL = "#{RDStation.host}/auth/token".freeze
     DEFAULT_HEADERS = { 'Content-Type' => 'application/json' }.freeze
-    REVOKE_URL = "#{RDStation.host}/auth/revoke".freeze
 
     def initialize(client_id = nil, client_secret = nil)
       warn_deprecation if client_id || client_secret
@@ -51,7 +49,7 @@ module RDStation
 
     def self.revoke(access_token:)
       response = self.post(
-        REVOKE_URL,
+        "#{RDStation.host}/auth/revoke",
         body: revoke_body(access_token),
         headers: revoke_headers(access_token)
       )
@@ -79,7 +77,7 @@ module RDStation
       body = default_body.merge(params)
 
       self.class.post(
-        AUTH_TOKEN_URL,
+        "#{RDStation.host}/auth/token",
         body: body.to_json,
         headers: DEFAULT_HEADERS
       )

--- a/lib/rdstation/events.rb
+++ b/lib/rdstation/events.rb
@@ -1,9 +1,9 @@
+# frozen_string_literal: true
+
 module RDStation
   class Events
     include HTTParty
     include ::RDStation::RetryableRequest
-
-    EVENTS_ENDPOINT = "#{RDStation.host}/platform/events".freeze
 
     def initialize(authorization:)
       @authorization = authorization
@@ -11,9 +11,15 @@ module RDStation
 
     def create(payload)
       retryable_request(@authorization) do |authorization|
-        response = self.class.post(EVENTS_ENDPOINT, headers: authorization.headers, body: payload.to_json)
+        response = self.class.post(base_url, headers: authorization.headers, body: payload.to_json)
         ApiResponse.build(response)
       end
+    end
+
+    private
+
+    def base_url
+      "#{RDStation.host}/platform/events"
     end
   end
 end

--- a/lib/rdstation/fields.rb
+++ b/lib/rdstation/fields.rb
@@ -1,11 +1,10 @@
-# encoding: utf-8
+# frozen_string_literal: true
+
 module RDStation
   # More info: https://developers.rdstation.com/pt-BR/reference/fields
   class Fields
     include HTTParty
     include ::RDStation::RetryableRequest
-
-    BASE_URL = "#{RDStation.host}/platform/contacts/fields".freeze
 
     def initialize(authorization:)
       @authorization = authorization
@@ -13,14 +12,14 @@ module RDStation
 
     def all
       retryable_request(@authorization) do |authorization|
-        response = self.class.get(BASE_URL, headers: authorization.headers)
+        response = self.class.get(base_url, headers: authorization.headers)
         ApiResponse.build(response)
       end
     end
 
     def create(payload)
       retryable_request(@authorization) do |authorization|
-        response = self.class.post(BASE_URL, headers: authorization.headers, body: payload.to_json)
+        response = self.class.post(base_url, headers: authorization.headers, body: payload.to_json)
         ApiResponse.build(response)
       end
     end
@@ -42,7 +41,7 @@ module RDStation
     private
 
     def base_url(path = '')
-      "#{BASE_URL}/#{path}"
+      "#{RDStation.host}/platform/contacts/fields/#{path}"
     end
   end
 end

--- a/lib/rdstation/version.rb
+++ b/lib/rdstation/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RDStation
-  VERSION = '2.5.2'.freeze
+  VERSION = '2.5.3'
 end

--- a/spec/lib/rdstation/fields_spec.rb
+++ b/spec/lib/rdstation/fields_spec.rb
@@ -1,6 +1,14 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RDStation::Fields do
+  before do
+    RDStation.configure do |config|
+      config.base_host = 'https://sample.rd.services'
+    end
+  end
+
   let(:valid_access_token) { 'valid_access_token' }
   let(:rdstation_fields_with_valid_token) do
     described_class.new(authorization: RDStation::Authorization.new(access_token: valid_access_token))
@@ -14,7 +22,7 @@ RSpec.describe RDStation::Fields do
   end
 
   describe '#all' do
-    let(:fields_endpoint) { 'https://api.rd.services/platform/contacts/fields' }
+    let(:fields_endpoint) { 'https://sample.rd.services/platform/contacts/fields/' }
     let(:all_account_fields) do
       {
         'fields' => [


### PR DESCRIPTION
The use of constants was ignoring the `RDStation.host`

```ruby
BASE_URL = "#{RDStation.host}/platform/contacts/fields".freeze
```

Was generating always: `https://api.rd.services/platform/contacts/fields`. We didn't catch this because the specs was passing and we did manual tests on other classes that does not use constants to build the url.

Specs didn't catch because we did not change the specs which use constants to use a custom url.


With this PR we will ensure that the url will be build correctly