### PR TITLE
Adds more api clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+Gemfile.lock
 
 # YARD artifacts
 .yardoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 2.6.0
+
+### Additions
+
+#### 1. New Emails client
+
+Usage example:
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.emails.all
+```
+
+#### 2. New Segmentations client
+
+Usage example:
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.segmentations.all
+```
+
 ## 2.5.1
 
 - Fixed checking `empty?` for nil values inside of InvalidRefreshToken class

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Upgrading? Check the [migration guide](#Migration-guide) before bumping to a new
    4. [Events](#Events)
    5. [Fields](#Fields)
    6. [Webhooks](#Webhooks)
-   7. [Errors](#Errors)
+   7. [Emails](#Emails)
+   8. [Segmentations](#Segmentations)
+   9. [Errors](#Errors)
 3. [Changelog](#Changelog)
 4. [Migration guide](#Migration-guide)
    1. [Upgrading from 1.2.x to 2.0.0](#Upgrading-from-1.2.x-to-2.0.0)
@@ -300,6 +302,39 @@ The required strucutre of the payload is [described here](https://developers.rds
 ```ruby
 client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
 client.webhooks.delete('WEBHOOK_UUID')
+```
+
+### Emails
+Endpoints to [Email](https://developers.rdstation.com/reference/get_platform-emails) information in your RD Station account.
+
+#### List all emails
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.emails.all
+```
+
+#### Get email by id
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.emails.by_id(id)
+```
+
+### Segmentations
+Endpoints to [Segmentation](https://developers.rdstation.com/reference/segmenta%C3%A7%C3%B5es) information in your RD Station account.
+#### List all segmentations
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.segmentations.all
+```
+
+#### Get the contact list with a specific segmentation
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.segmentations.contacts(segmentation_id)
 ```
 
 ### Errors

--- a/README.md
+++ b/README.md
@@ -314,6 +314,13 @@ client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'ref
 client.emails.all
 ```
 
+#### List emails using query params
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+query_params = {page_size: 10, page: 1}
+client.emails.all(query_params)
+```
+
 #### Get email by id
 
 ```ruby

--- a/lib/rdstation-ruby-client.rb
+++ b/lib/rdstation-ruby-client.rb
@@ -13,6 +13,7 @@ require 'rdstation/contacts'
 require 'rdstation/events'
 require 'rdstation/fields'
 require 'rdstation/webhooks'
+require 'rdstation/emails'
 
 # Error handling
 require 'rdstation/error'

--- a/lib/rdstation-ruby-client.rb
+++ b/lib/rdstation-ruby-client.rb
@@ -13,6 +13,7 @@ require 'rdstation/contacts'
 require 'rdstation/events'
 require 'rdstation/fields'
 require 'rdstation/webhooks'
+require 'rdstation/segmentations'
 require 'rdstation/emails'
 
 # Error handling

--- a/lib/rdstation/client.rb
+++ b/lib/rdstation/client.rb
@@ -24,6 +24,10 @@ module RDStation
       @webhooks ||= RDStation::Webhooks.new(authorization: @authorization)
     end
 
+    def emails
+      @emails ||= RDStation::Emails.new(authorization: @authorization)
+    end
+
     private
 
     def warn_deprecation

--- a/lib/rdstation/client.rb
+++ b/lib/rdstation/client.rb
@@ -24,6 +24,10 @@ module RDStation
       @webhooks ||= RDStation::Webhooks.new(authorization: @authorization)
     end
 
+    def segmentations
+      @segmentations ||= RDStation::Segmentations.new(authorization: @authorization)
+    end
+
     def emails
       @emails ||= RDStation::Emails.new(authorization: @authorization)
     end

--- a/lib/rdstation/emails.rb
+++ b/lib/rdstation/emails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RDStation
   class Emails
     include HTTParty
@@ -7,9 +9,9 @@ module RDStation
       @authorization = authorization
     end
 
-    def all
+    def all(query_params={})
       retryable_request(@authorization) do |authorization|
-        response = self.class.get(base_url, headers: authorization.headers)
+        response = self.class.get(base_url, headers: authorization.headers, query: query_params)
         ApiResponse.build(response)
       end
     end
@@ -23,7 +25,7 @@ module RDStation
 
     private
 
-    def base_url(path = '')
+    def base_url(path='')
       "#{RDStation.host}/platform/emails/#{path}"
     end
   end

--- a/lib/rdstation/emails.rb
+++ b/lib/rdstation/emails.rb
@@ -1,0 +1,30 @@
+module RDStation
+  class Emails
+    include HTTParty
+    include ::RDStation::RetryableRequest
+
+    def initialize(authorization:)
+      @authorization = authorization
+    end
+
+    def all
+      retryable_request(@authorization) do |authorization|
+        response = self.class.get(base_url, headers: authorization.headers)
+        ApiResponse.build(response)
+      end
+    end
+
+    def by_id(id)
+      retryable_request(@authorization) do |authorization|
+        response = self.class.get(base_url(id), headers: authorization.headers)
+        ApiResponse.build(response)
+      end
+    end
+
+    private
+
+    def base_url(path = '')
+      "#{RDStation.host}/platform/emails/#{path}"
+    end
+  end
+end

--- a/lib/rdstation/segmentations.rb
+++ b/lib/rdstation/segmentations.rb
@@ -1,0 +1,30 @@
+module RDStation
+  class Segmentations
+    include HTTParty
+    include ::RDStation::RetryableRequest
+
+    def initialize(authorization:)
+      @authorization = authorization
+    end
+
+    def all
+      retryable_request(@authorization) do |authorization|
+        response = self.class.get(base_url, headers: authorization.headers)
+        ApiResponse.build(response)
+      end
+    end
+
+    def contacts(segmentation_id)
+      retryable_request(@authorization) do |authorization|
+        response = self.class.get(base_url("#{segmentation_id}/contacts"), headers: authorization.headers)
+        ApiResponse.build(response)
+      end
+    end
+
+    private
+
+    def base_url(path = '')
+      "#{RDStation.host}/platform/segmentations/#{path}"
+    end
+  end
+end

--- a/lib/rdstation/version.rb
+++ b/lib/rdstation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RDStation
-  VERSION = '2.5.3'
+  VERSION = '2.6.0'
 end

--- a/spec/lib/rdstation/emails_spec.rb
+++ b/spec/lib/rdstation/emails_spec.rb
@@ -1,0 +1,143 @@
+require 'spec_helper'
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe RDStation::Emails do
+  let(:emails_client) do
+    described_class.new(authorization: RDStation::Authorization.new(access_token: 'access_token'))
+  end
+
+  let(:emails_endpoint) { 'https://api.rd.services/platform/emails/' }
+
+  let(:headers) do
+    {
+      Authorization: 'Bearer access_token',
+      'Content-Type': 'application/json'
+    }
+  end
+
+  let(:error_handler) do
+    instance_double(RDStation::ErrorHandler, raise_error: 'mock raised errors')
+  end
+
+  before do
+    allow(RDStation::ErrorHandler).to receive(:new).and_return(error_handler)
+  end
+
+  describe '#all' do
+    it 'calls retryable_request' do
+      expect(emails_client).to receive(:retryable_request)
+      emails_client.all
+    end
+
+    context 'when the request is successful' do
+      let(:emails) do
+        {
+          items: [
+            {
+              id: 123,
+              name: 'Marketing email',
+              created_at: '2017-11-21T20:00:00-02:00',
+              updated_at: '2017-11-21T20:00:00-02:00',
+              send_at: '2017-11-21T20:00:00-02:00',
+              leads_count: 55_000,
+              status: 'FINISHED',
+              type: 'email_model',
+              is_predictive_sending: false,
+              sending_is_imminent: false,
+              behavior_score_info: {
+                disengaged: false,
+                engaged: false,
+                indeterminate: false
+              },
+              campaign_id: 123,
+              component_template_id: 123
+            }
+          ],
+          total: 1
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, emails_endpoint)
+          .with(headers: headers)
+          .to_return(status: 200, body: emails.to_json)
+      end
+
+      it 'returns all emails' do
+        response = emails_client.all
+        expect(response).to eq(emails)
+      end
+    end
+
+    context 'when the response contains errors' do
+      before do
+        stub_request(:get, emails_endpoint)
+          .with(headers: headers)
+          .to_return(status: 400, body: { 'errors' => ['all errors'] }.to_json)
+      end
+
+      it 'calls raise_error on error handler' do
+        emails_client.all
+        expect(error_handler).to have_received(:raise_error)
+      end
+    end
+  end
+
+  describe '#by_id' do
+    let(:id) { 123 }
+    let(:emails_endpoint_by_id) { emails_endpoint + id.to_s }
+
+    it 'calls retryable_request' do
+      expect(emails_client).to receive(:retryable_request)
+      emails_client.by_id(id)
+    end
+
+    context 'when the request is successful' do
+      let(:email) do
+        {
+          id: 123,
+          name: 'Marketing email',
+          created_at: '2017-11-21T20:00:00-02:00',
+          updated_at: '2017-11-21T20:00:00-02:00',
+          send_at: '2017-11-21T20:00:00-02:00',
+          leads_count: 55_000,
+          status: 'FINISHED',
+          type: 'email_model',
+          is_predictive_sending: false,
+          sending_is_imminent: false,
+          behavior_score_info: {
+            disengaged: false,
+            engaged: false,
+            indeterminate: false
+          },
+          campaign_id: 123,
+          component_template_id: 123
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, emails_endpoint_by_id)
+          .with(headers: headers)
+          .to_return(status: 200, body: email.to_json)
+      end
+
+      it 'returns the email' do
+        response = emails_client.by_id(id)
+        expect(response).to eq(email)
+      end
+    end
+
+    context 'when the response contains errors' do
+      before do
+        stub_request(:get, emails_endpoint_by_id)
+          .with(headers: headers)
+          .to_return(status: 400, body: { 'errors' => ['all errors'] }.to_json)
+      end
+
+      it 'calls raise_error on error handler' do
+        emails_client.by_id(id)
+        expect(error_handler).to have_received(:raise_error)
+      end
+    end
+  end
+end

--- a/spec/lib/rdstation/segmentations_spec.rb
+++ b/spec/lib/rdstation/segmentations_spec.rb
@@ -1,0 +1,138 @@
+require 'spec_helper'
+
+RSpec.describe RDStation::Segmentations do
+  let(:segmentations_client) do
+    described_class.new(authorization: RDStation::Authorization.new(access_token: 'access_token'))
+  end
+
+  let(:segmentations_endpoint) { 'https://api.rd.services/platform/segmentations/' }
+
+  let(:headers) do
+    {
+      Authorization: 'Bearer access_token',
+      'Content-Type': 'application/json'
+    }
+  end
+
+  let(:error_handler) do
+    instance_double(RDStation::ErrorHandler, raise_error: 'mock raised errors')
+  end
+
+  before do
+    allow(RDStation::ErrorHandler).to receive(:new).and_return(error_handler)
+  end
+
+  describe '#all' do
+    it 'calls retryable_request' do
+      expect(segmentations_client).to receive(:retryable_request)
+      segmentations_client.all
+    end
+
+    context 'when the request is successful' do
+      let(:segmentations) do
+        {
+          segmentations: [
+            {
+              id: 1,
+              name: 'Todos os contatos da base',
+              standard: true,
+              created_at: '2021-09-24T14:14:04.510-03:00',
+              updated_at: '2021-09-24T14:14:04.510-03:00',
+              process_status: 'processed',
+              links: [
+                {
+                  rel: 'SELF',
+                  href: 'https://api.rd.services/platform/segmentations/1/contacts',
+                  media: 'application/json',
+                  type: 'GET'
+                }
+              ]
+            }
+          ]
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, segmentations_endpoint)
+          .with(headers: headers)
+          .to_return(status: 200, body: segmentations.to_json)
+      end
+
+      it 'returns all segmentations' do
+        response = segmentations_client.all
+        expect(response).to eq(segmentations)
+      end
+    end
+
+    context 'when the response contains errors' do
+      before do
+        stub_request(:get, segmentations_endpoint)
+          .with(headers: headers)
+          .to_return(status: 400, body: { 'errors' => ['all errors'] }.to_json)
+      end
+
+      it 'calls raise_error on error handler' do
+        segmentations_client.all
+        expect(error_handler).to have_received(:raise_error)
+      end
+    end
+  end
+
+  describe '#contacts' do
+    let(:segmentation_id) { 123 }
+    let(:segmentations_endpoint_by_contacts) { segmentations_endpoint + "#{segmentation_id}/contacts" }
+
+    it 'calls retryable_request' do
+      expect(segmentations_client).to receive(:retryable_request)
+      segmentations_client.contacts(segmentation_id)
+    end
+
+    context 'when the request is successful' do
+      let(:contact) do
+        {
+          contacts: [
+            {
+              uuid: '5408c5a3-4711-4f2e-8d0b-13407a3e30f3',
+              name: 'Lead Example 1',
+              email: 'leadexample1@example.com',
+              last_conversion_date: '2021-09-13T15:01:06.325-03:00',
+              created_at: '2021-09-13T15:01:06.325-03:00',
+              links: [
+                {
+                  rel: 'SELF',
+                  href: 'https://api.rd.services/platform/contacts/5408c5a3-4711-4f2e-8d0b-13407a3e30f3',
+                  media: 'application/json',
+                  type: 'GET'
+                }
+              ]
+            }
+          ]
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, segmentations_endpoint_by_contacts)
+          .with(headers: headers)
+          .to_return(status: 200, body: contact.to_json)
+      end
+
+      it 'returns the contact' do
+        response = segmentations_client.contacts(segmentation_id)
+        expect(response).to eq(contact)
+      end
+    end
+
+    context 'when the response contains errors' do
+      before do
+        stub_request(:get, segmentations_endpoint_by_contacts)
+          .with(headers: headers)
+          .to_return(status: 400, body: { 'errors' => ['all errors'] }.to_json)
+      end
+
+      it 'calls raise_error on error handler' do
+        segmentations_client.contacts(segmentation_id)
+        expect(error_handler).to have_received(:raise_error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What was done

- Add clients for email and segmentation
- Add tests for the new clients
- Add gemfile.lock in .gitignore

### How to test?

#### Adding gem on your project

1. Clone [the repository](https://github.com/Hilderlan/rdstation-ruby-client) in the same directory of the project you want to use rdstation-ruby-client gem
2. In the Gemfile, put `gem 'rdstation-ruby-client', path: '/var/rdstation-ruby-client'`
3. If you're using docker-compose, add a volume to make sure the path to the local gem will exist:
 ```
volumes:
            (...)
            - ../rdstation-ruby-client:/var/rdstation-ruby-client
            (...)
```
4. Access the console of your application and follow the steps below

#### Emails client

1. Follow the [instructions](https://github.com/ResultadosDigitais/rdstation-ruby-client#getting-access_token) described in the readme to generate an `access_token` on your project
5. Define a client with: `client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')`
6. Run `client.emails.all`

Running tests

1. `bundle install`
2. Run the tests for this client with `bundle exec rspec spec/lib/rdstation/emails_spec.rb`

---
#### Segmentations client

1. Follow the [instructions](https://github.com/ResultadosDigitais/rdstation-ruby-client#getting-access_token) described in the readme to generate an `access_token` on your project
2. Define a client with: `client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')`
3. Run `client.segmentations.all`

Running tests

1. `bundle install`
2. Run the tests for this client with `bundle exec rspec spec/lib/rdstation/segmentations_spec.rb`