### PR TITLE
change gemfile.lock for rdstation-ruby-client.gemspec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          - v1-dependencies-{{ checksum "rdstation-ruby-client.gemspec" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
@@ -34,7 +34,7 @@ jobs:
       - save_cache:
           paths:
             - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+          key: v1-dependencies-{{ checksum "rdstation-ruby-client.gemspec" }}
         
       # run tests!
       - run:


### PR DESCRIPTION
# Descrição
Com o ignore do Gemfile.lock, o CI começou a quebrar. Esse pr ajusta o CI para validar o arquivo de deps.