### PR TITLE
Fix intermittent spec: Ensure the correct base host is set

### DIFF
--- a/spec/lib/rdstation/fields_spec.rb
+++ b/spec/lib/rdstation/fields_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe RDStation::Fields do
     end
   end
 
+  after do
+    RDStation.configure do |config|
+      config.base_host = 'https://api.rd.services'
+    end
+  end
+
   let(:valid_access_token) { 'valid_access_token' }
   let(:rdstation_fields_with_valid_token) do
     described_class.new(authorization: RDStation::Authorization.new(access_token: valid_access_token))


### PR DESCRIPTION
# Problem

We have intermittent specs. eg: seed 64747

## How to solve:
Ensure that `api.rd.services` will be the base_host after a given spec execution.

In order to do not broken other tests we need to set the `api.rd.services` as the base host as it was before.

### Reproduce:

Inside the `master` branch run the specs with the give seed: `rspec --seed 64747` 
You should get something like: 
<img width="434" alt="image" src="https://user-images.githubusercontent.com/1313442/195629826-f0791950-6cd0-4b0a-884b-a135fe3bfc0f.png">

Then inside `fix-intermittent-specs` branch, run it again, and the spec should be fixed

<img width="582" alt="image" src="https://user-images.githubusercontent.com/1313442/195629984-ce84194b-62e3-466b-a360-598bd65b9df7.png">


Broken build ref: https://app.circleci.com/pipelines/github/ResultadosDigitais/rdstation-ruby-client/143/workflows/0ffe438a-3bc1-4f43-b973-d318297d2f13/jobs/135