### PR TITLE
Makes the retryable_request method also retry when a `RDStation::Error::Unauthorized` error happen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.1
+
+- Makes the retryable_request method also retry when a `RDStation::Error::Unauthorized` error happen
+
 ## 2.6.0
 
 ### Additions

--- a/lib/rdstation/retryable_request.rb
+++ b/lib/rdstation/retryable_request.rb
@@ -7,7 +7,7 @@ module RDStation
       retries = 0
       begin
         yield authorization
-      rescue ::RDStation::Error::ExpiredAccessToken => e
+      rescue ::RDStation::Error::ExpiredAccessToken, ::RDStation::Error::Unauthorized => e
         raise if !retry_possible?(authorization) || retries >= MAX_RETRIES
 
         retries += 1

--- a/lib/rdstation/version.rb
+++ b/lib/rdstation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RDStation
-  VERSION = '2.6.0'
+  VERSION = '2.6.1'
 end


### PR DESCRIPTION
### What was done

- Add a new error type for the `retryable_request` method to handle

### How to test?

#### Adding gem on your project

1. Clone [the repository](https://github.com/Hilderlan/rdstation-ruby-client) in the same directory of the project you want to use rdstation-ruby-client gem
2. In the Gemfile, put `gem 'rdstation-ruby-client', path: '/var/rdstation-ruby-client'`
3. If you're using docker-compose, add a volume to make sure the path to the local gem will exist:
 ```
volumes:
            (...)
            - ../rdstation-ruby-client:/var/rdstation-ruby-client
            (...)
```
4. Access the console of your application and follow the steps below

#### Making a request with an invalid token

1. Follow the [instructions](https://github.com/ResultadosDigitais/rdstation-ruby-client#getting-access_token) described in the readme to generate an `access_token` on your project
5. Define a client with: `client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')`
6. Run `client.emails.all`
7. The generated access_token is valid for 24 hours, so make another request when it has expired
8. The request must be successful even after 24 hours.

Running tests

1. `bundle install`
2. Run the tests for this client with `bundle exec rspec spec/lib/rdstation/emails_spec.rb`