### PR TITLE
Add analytics client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.7.0
+
+### Additions
+
+#### 1. New Analytics client
+
+Usage example:
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+query_parms =  { start_date:'2022-11-02', end_date:'2022-11-08' }
+client.analytics.email_marketing(query_params)
+```
+
 ## 2.6.0
 
 ### Additions

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Upgrading? Check the [migration guide](#Migration-guide) before bumping to a new
    6. [Webhooks](#Webhooks)
    7. [Emails](#Emails)
    8. [Segmentations](#Segmentations)
-   9. [Errors](#Errors)
+   9. [Analytics](#Analytics)
+   10. [Errors](#Errors)
 3. [Changelog](#Changelog)
 4. [Migration guide](#Migration-guide)
    1. [Upgrading from 1.2.x to 2.0.0](#Upgrading-from-1.2.x-to-2.0.0)
@@ -343,7 +344,17 @@ client.segmentations.all
 client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
 client.segmentations.contacts(segmentation_id)
 ```
+### Analytics
+Endpoints to [Analytics](https://developers.rdstation.com/reference/get_platform-analytics-emails) information in your RD Station account.
 
+#### List all email marketing analytics data
+- NOTE: The query params `start_date`(yyyy-mm-dd)  and `end_date`(yyyy-mm-dd) are required
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+query_parms =  { start_date:'2022-11-02', end_date:'2022-11-08' }
+client.analytics.email_marketing(query_params)
+```
 ### Errors
 
 Each endpoint may raise errors accoording to the HTTP response code from RDStation:

--- a/lib/rdstation-ruby-client.rb
+++ b/lib/rdstation-ruby-client.rb
@@ -15,6 +15,7 @@ require 'rdstation/fields'
 require 'rdstation/webhooks'
 require 'rdstation/segmentations'
 require 'rdstation/emails'
+require 'rdstation/analytics'
 
 # Error handling
 require 'rdstation/error'

--- a/lib/rdstation/analytics.rb
+++ b/lib/rdstation/analytics.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RDStation
+  class Analytics
+    include HTTParty
+    include ::RDStation::RetryableRequest
+
+    def initialize(authorization:)
+      @authorization = authorization
+    end
+
+    def email_marketing(query_params={})
+      retryable_request(@authorization) do |authorization|
+        response = self.class.get(base_url, headers: authorization.headers, query: query_params)
+        ApiResponse.build(response)
+      end
+    end
+
+    private
+
+    def base_url
+      "#{RDStation.host}/platform/analytics/emails"
+    end
+  end
+end

--- a/lib/rdstation/client.rb
+++ b/lib/rdstation/client.rb
@@ -32,6 +32,10 @@ module RDStation
       @emails ||= RDStation::Emails.new(authorization: @authorization)
     end
 
+    def analytics
+      @analytics ||= RDStation::Analytics.new(authorization: @authorization)
+    end
+
     private
 
     def warn_deprecation

--- a/lib/rdstation/version.rb
+++ b/lib/rdstation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RDStation
-  VERSION = '2.6.0'
+  VERSION = '2.7.0'
 end

--- a/spec/lib/rdstation/analytics_spec.rb
+++ b/spec/lib/rdstation/analytics_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+RSpec.describe RDStation::Analytics do
+  let(:analytics_client) do
+    described_class.new(authorization: RDStation::Authorization.new(access_token: 'access_token'))
+  end
+
+  let(:analytics_endpoint) { 'https://api.rd.services/platform/analytics/emails' }
+
+  let(:headers) do
+    {
+      Authorization: 'Bearer access_token',
+      'Content-Type': 'application/json'
+    }
+  end
+
+  let(:error_handler) do
+    instance_double(RDStation::ErrorHandler, raise_error: 'mock raised errors')
+  end
+
+  before do
+    allow(RDStation::ErrorHandler).to receive(:new).and_return(error_handler)
+  end
+
+  describe '#email_marketing' do
+    let(:analytics_list) do
+      {
+        account_id: 1,
+        query_date: {
+          start_date: "2022-11-08",
+          end_date: "2022-11-08"
+        },
+        emails: [
+          {
+            campaign_id: 6061281,
+            campaign_name: "Desconto",
+            send_at: "2021-08-06T17:26:39-03:00",
+            contacts_count: 1000,
+            email_dropped_count: 3,
+            email_delivered_count: 997,
+            email_bounced_count: 5,
+            email_opened_count: 500,
+            email_clicked_count: 500,
+            email_unsubscribed_count: 4,
+            email_spam_reported_count: 1,
+            email_delivered_rate: 98.7,
+            email_opened_rate: 46.9,
+            email_clicked_rate: 36.5,
+            email_spam_reported_rate: 0
+          }
+        ]
+      }.to_json
+    end
+
+    it 'calls retryable_request' do
+      expect(analytics_client).to receive(:retryable_request)
+      analytics_client.email_marketing
+    end
+
+    context 'when the request is successful' do
+      before do
+        stub_request(:get, analytics_endpoint)
+          .with(headers: headers)
+          .to_return(status: 200, body: analytics_list.to_json)
+      end
+
+      it 'returns all email marketing analytics data' do
+        response = analytics_client.email_marketing
+        expect(response).to eq(analytics_list)
+      end
+    end
+
+    context 'when the request contains query params' do
+      let(:query_params) do
+        {
+          start_date:'2022-11-2',
+          end_date:'2022-11-8',
+          campaign_id: '6061281'
+        }
+      end
+
+      before do
+        stub_request(:get, analytics_endpoint)
+          .with(headers: headers, query: query_params)
+          .to_return(status: 200, body: analytics_list.to_json)
+      end
+
+      it 'returns email marketing analytics data filtered by the query params' do
+        response = analytics_client.email_marketing(query_params)
+        expect(response).to eq(analytics_list)
+      end
+    end
+
+    context 'when the response contains errors' do
+      before do
+        stub_request(:get, analytics_endpoint)
+          .with(headers: headers)
+          .to_return(status: 400, body: { 'errors' => ['all errors'] }.to_json)
+      end
+
+      it 'calls raise_error on error handler' do
+        analytics_client.email_marketing
+        expect(error_handler).to have_received(:raise_error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What was done
Add client for analytics 
Add tests for the new client

## How to test?
### Running tests (rspec) in this project

1. `bundle install`
2. Run the tests for this client with `bundle exec rspec spec/lib/rdstation/analytics_spec.rb`

### **Adding gem on your project**

1. Clone [the repository](https://github.com/ResultadosDigitais/rdstation-ruby-client)
2. Access branch `add-analytics-client`
3. In the Gemfile of your project, put `gem 'rdstation-ruby-client', path: '/var/rdstation-ruby-client'`
4. If you're using docker-compose, add a volume to make sure the path to the local gem will exist:
    
    ```ruby
    volumes:
    	(...)
    	- ../rdstation-ruby-client:/var/rdstation-ruby-client
    	(...)
    ```
    
5. Run `bundle install`
6. Access the console of your application and follow the steps below:

- Follow the [instructions](https://github.com/ResultadosDigitais/rdstation-ruby-client#getting-access_token) described in the readme to generate an `access_token` on your project

 ```
client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
query_parms =  { start_date:'2022-11-02', end_date:'2022-11-08' }
client.analytics.email_marketing(query_params)
```
