### PR TITLE
Add landing_pages and conversion analytics client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 2.8.0
+
+### Additions
+
+#### 1. New Analytics client: conversions
+
+Usage example:
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+query_params =  { start_date:'2022-11-13', end_date:'2022-11-15', assets_type:['LandingPage'] }
+client.analytics.conversions(query_params)
+```
+
+#### 2. New landing_pages client
+
+Usage example:
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.landing_pages.all
+```
+
 ## 2.7.0
 
 ### Additions
@@ -8,7 +31,7 @@ Usage example:
 
 ```ruby
 client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
-query_parms =  { start_date:'2022-11-02', end_date:'2022-11-08' }
+query_params =  { start_date:'2022-11-02', end_date:'2022-11-08' }
 client.analytics.email_marketing(query_params)
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Upgrading? Check the [migration guide](#Migration-guide) before bumping to a new
    7. [Emails](#Emails)
    8. [Segmentations](#Segmentations)
    9. [Analytics](#Analytics)
-   10. [Errors](#Errors)
+   10.[LandingPages](#LandingPages)
+   11.[Errors](#Errors)
 3. [Changelog](#Changelog)
 4. [Migration guide](#Migration-guide)
    1. [Upgrading from 1.2.x to 2.0.0](#Upgrading-from-1.2.x-to-2.0.0)
@@ -345,16 +346,37 @@ client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'ref
 client.segmentations.contacts(segmentation_id)
 ```
 ### Analytics
-Endpoints to [Analytics](https://developers.rdstation.com/reference/get_platform-analytics-emails) information in your RD Station account.
+Endpoints to [Analytics](https://developers.rdstation.com/reference/estatisticas) information in your RD Station account.
 
-#### List all email marketing analytics data
+#### => List all EMAIL MARKETING analytics data
+Endpoints to [Analytics - Email marketing](https://developers.rdstation.com/reference/get_platform-analytics-emails) information in your RD Station account.
 - NOTE: The query params `start_date`(yyyy-mm-dd)  and `end_date`(yyyy-mm-dd) are required
 
 ```ruby
 client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
-query_parms =  { start_date:'2022-11-02', end_date:'2022-11-08' }
+query_params =  { start_date:'2022-11-02', end_date:'2022-11-08' }
 client.analytics.email_marketing(query_params)
 ```
+
+#### => List CONVERSIONS analytics data
+Endpoints to [Analytics - Conversions](https://developers.rdstation.com/reference/get_platform-analytics-conversions) information in your RD Station account.
+- NOTE: The query params `start_date`(yyyy-mm-dd) and `end_date`(yyyy-mm-dd) are required.
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+query_params =  { start_date:'2022-11-13', end_date:'2022-11-15', assets_type:['LandingPage'] }
+client.analytics.conversions(query_params)
+```
+
+### LandingPages
+Endpoints to [LandingPages](https://developers.rdstation.com/reference/get_platform-landing-pages) information in your RD Station account.
+#### List all landing_pages
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.landing_pages.all
+```
+
 ### Errors
 
 Each endpoint may raise errors accoording to the HTTP response code from RDStation:

--- a/lib/rdstation-ruby-client.rb
+++ b/lib/rdstation-ruby-client.rb
@@ -16,6 +16,7 @@ require 'rdstation/webhooks'
 require 'rdstation/segmentations'
 require 'rdstation/emails'
 require 'rdstation/analytics'
+require 'rdstation/landing_pages'
 
 # Error handling
 require 'rdstation/error'

--- a/lib/rdstation/analytics.rb
+++ b/lib/rdstation/analytics.rb
@@ -11,15 +11,22 @@ module RDStation
 
     def email_marketing(query_params={})
       retryable_request(@authorization) do |authorization|
-        response = self.class.get(base_url, headers: authorization.headers, query: query_params)
+        response = self.class.get(base_url('emails'), headers: authorization.headers, query: query_params)
+        ApiResponse.build(response)
+      end
+    end
+
+    def conversions(query_params={})
+      retryable_request(@authorization) do |authorization|
+        response = self.class.get(base_url('conversions'), headers: authorization.headers, query: query_params)
         ApiResponse.build(response)
       end
     end
 
     private
 
-    def base_url
-      "#{RDStation.host}/platform/analytics/emails"
+    def base_url(path='')
+      "#{RDStation.host}/platform/analytics/#{path}"
     end
   end
 end

--- a/lib/rdstation/client.rb
+++ b/lib/rdstation/client.rb
@@ -36,6 +36,10 @@ module RDStation
       @analytics ||= RDStation::Analytics.new(authorization: @authorization)
     end
 
+    def landing_pages
+      @landing_pages ||= RDStation::LandingPages.new(authorization: @authorization)
+    end
+
     private
 
     def warn_deprecation

--- a/lib/rdstation/landing_pages.rb
+++ b/lib/rdstation/landing_pages.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RDStation
+  class LandingPages
+    include HTTParty
+    include ::RDStation::RetryableRequest
+
+    def initialize(authorization:)
+      @authorization = authorization
+    end
+
+    def all(query_params={})
+      retryable_request(@authorization) do |authorization|
+        response = self.class.get(base_url, headers: authorization.headers, query: query_params)
+        ApiResponse.build(response)
+      end
+    end
+
+    private
+
+    def base_url(path='')
+      "#{RDStation.host}/platform/landing_pages/#{path}"
+    end
+  end
+end

--- a/lib/rdstation/version.rb
+++ b/lib/rdstation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RDStation
-  VERSION = '2.7.0'
+  VERSION = '2.8.0'
 end

--- a/spec/lib/rdstation/landing_pages_spec.rb
+++ b/spec/lib/rdstation/landing_pages_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+RSpec.describe RDStation::LandingPages do
+  let(:landing_pages_client) do
+    described_class.new(authorization: RDStation::Authorization.new(access_token: 'access_token'))
+  end
+  let(:landing_pages_endpoint) { 'https://api.rd.services/platform/landing_pages/' }
+
+  let(:headers) do
+    {
+      Authorization: 'Bearer access_token',
+      'Content-Type': 'application/json'
+    }
+  end
+  let(:error_handler) do
+    instance_double(RDStation::ErrorHandler, raise_error: 'mock raised errors')
+  end
+
+  before do
+    allow(RDStation::ErrorHandler).to receive(:new).and_return(error_handler)
+  end
+
+  describe '#all' do
+    let(:landing_pages_list) do
+      [
+        {
+          id: 1,
+          title: "Minha Primeira Landing Page",
+          created_at: "2021-09-22T14:14:04.510-03:00",
+          upated_at: "2021-09-24T14:14:04.510-03:00",
+          conversion_identifier: "dia-das-mães-2022",
+          status: "PUBLISHED",
+          has_active_experiment: false,
+          had_experiment: false
+        }
+      ].to_json
+    end
+
+    it 'calls retryable_request' do
+      expect(landing_pages_client).to receive(:retryable_request)
+      landing_pages_client.all
+    end
+
+    context 'when the request is successful' do
+      before do
+        stub_request(:get, landing_pages_endpoint)
+          .with(headers: headers)
+          .to_return(status: 200, body: landing_pages_list.to_json)
+      end
+
+      it 'returns all email marketing analytics data' do
+        response = landing_pages_client.all
+        expect(response).to eq(landing_pages_list)
+      end
+    end
+
+    context 'when the request contains query params' do
+      let(:query_params) { { page: 1 } }
+
+      before do
+        stub_request(:get, landing_pages_endpoint)
+          .with(headers: headers, query: query_params)
+          .to_return(status: 200, body: landing_pages_list.to_json)
+      end
+
+      it 'returns email marketing analytics data filtered by the query params' do
+        response = landing_pages_client.all(query_params)
+        expect(response).to eq(landing_pages_list)
+      end
+    end
+
+    context 'when the response contains errors' do
+      before do
+        stub_request(:get, landing_pages_endpoint)
+          .with(headers: headers)
+          .to_return(status: 400, body: { 'errors' => ['all errors'] }.to_json)
+      end
+
+      it 'calls raise_error on error handler' do
+        landing_pages_client.all
+        expect(error_handler).to have_received(:raise_error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What was done
- Add client for analytics: Conversions
- Add client for Landing_Pages
- Add tests for new clients
- Update documentation

## How to test?
### Running tests (rspec) in this project:
  `bundle install`
  Run the tests for this clients with
`bundle exec rspec spec/lib/rdstation/analytics_spec.rb`
`bundle exec rspec spec/lib/rdstation/landing_pages_spec.rb`

### Adding gem on your project for more tests:
Clone [the repository](https://github.com/ResultadosDigitais/rdstation-ruby-client)
  
Access branch `add-lp-and-stats-client`
  
In the Gemfile of your project, put gem `'rdstation-ruby-client', path: '/var/rdstation-ruby-client'`
  
If you're using docker-compose, add a volume to make sure the path to the local gem will exist:
  
```
volumes:
  (...)
  - ../rdstation-ruby-client:/var/rdstation-ruby-client
  (...)
```
Run `bundle install`
  
Access the console of your application and follow the steps below:
  
Follow the [instructions](https://github.com/ResultadosDigitais/rdstation-ruby-client#getting-access_token) described in the readme to generate an access_token on your project
- Analytics: Conversions:
```
client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
query_params =  { start_date:'2022-11-13', end_date:'2022-11-15', assets_type:['LandingPage'] }
client.analytics.conversions(query_params)
```

- Landing_pages:
```ruby
client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
client.landing_pages.all
```