### PR TITLE
Fix too many requests format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.2
+
+- Fix TooManyRequest handler
+
 ## 2.8.1
 
 - Makes the retryable_request method also retry when a `RDStation::Error::Unauthorized` error happen

--- a/lib/rdstation/error/format.rb
+++ b/lib/rdstation/error/format.rb
@@ -29,7 +29,7 @@ module RDStation
       def single_hash?
         return unless @errors.is_a?(Hash)
 
-        @errors.key?('error')
+        @errors.key?('error') || @errors.key?('message')
       end
 
       def flat_hash?

--- a/lib/rdstation/error/formatter.rb
+++ b/lib/rdstation/error/formatter.rb
@@ -5,8 +5,9 @@ require_relative './format'
 module RDStation
   class Error
     class Formatter
-      def initialize(error_response)
+      def initialize(error_response, headers = {})
         @error_response = error_response
+        @headers = headers
       end
 
       def to_array
@@ -35,7 +36,8 @@ module RDStation
         [
           {
             'error_type' => 'TOO_MANY_REQUESTS',
-            'error_message' => error_message
+            'error_message' => error_message,
+            'details' => error_hash.key?('max') ? error_hash : error_details
           }
         ]
       end
@@ -100,6 +102,14 @@ module RDStation
           errors = build_error_from_array(attribute_name, attribute_errors)
           array_of_errors.push(*errors)
         end
+      end
+
+      def error_details
+        {
+          max: @headers.fetch('ratelimit-limit-quotas', 0),
+          usage: @headers.fetch('ratelimit-limit-quotas', 0),
+          remaining_time: @headers.fetch('retry-after-quotas', 0)
+        }
       end
     end
   end

--- a/lib/rdstation/error/formatter.rb
+++ b/lib/rdstation/error/formatter.rb
@@ -30,13 +30,12 @@ module RDStation
 
       def from_single_hash
         error_hash = @error_response.dup
-        error_message = error_hash.delete('error')
+        error_message = error_hash.delete('error') || error_hash.delete('message')
 
         [
           {
             'error_type' => 'TOO_MANY_REQUESTS',
-            'error_message' => error_message,
-            'details' => error_hash
+            'error_message' => error_message
           }
         ]
       end

--- a/lib/rdstation/error_handler.rb
+++ b/lib/rdstation/error_handler.rb
@@ -54,7 +54,7 @@ module RDStation
     end
 
     def error_formatter
-      @error_formatter = RDStation::Error::Formatter.new(response_errors)
+      @error_formatter = RDStation::Error::Formatter.new(response_errors, response.headers)
     end
 
     def additional_error_attributes

--- a/lib/rdstation/version.rb
+++ b/lib/rdstation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RDStation
-  VERSION = '2.8.1'
+  VERSION = '2.8.2'
 end

--- a/spec/lib/rdstation/error/formatter_spec.rb
+++ b/spec/lib/rdstation/error/formatter_spec.rb
@@ -218,31 +218,51 @@ RSpec.describe RDStation::Error::Formatter do
 
     context 'when receives a single hash of errors' do
       let(:error_format) { instance_double(RDStation::Error::Format, format: RDStation::Error::Format::SINGLE_HASH) }
-
-      let(:error_response) do
-        {
-          'error' => "'lead_limiter' rate limit exceeded for 86400 second(s) period for key",
-          'max' => 24,
-          'usage' => 55,
-          'remaining_time' => 20745
-        }
-      end
-
       let(:error_formatter) { described_class.new(error_response) }
 
-      let(:expected_result) do
-        [
+      context 'when response comes from RDSM' do
+        let(:error_response) do
           {
-            'error_type' => 'TOO_MANY_REQUESTS',
-            'error_message' => "'lead_limiter' rate limit exceeded for 86400 second(s) period for key",
-            'details' => { 'max' => 24, 'usage' => 55, 'remaining_time' => 20745 }
+            'error' => "'lead_limiter' rate limit exceeded for 86400 second(s) period for key",
+            'max' => 24,
+            'usage' => 55,
+            'remaining_time' => 20745
           }
-        ]
+        end
+
+        let(:expected_result) do
+          [
+            {
+              'error_type' => 'TOO_MANY_REQUESTS',
+              'error_message' => "'lead_limiter' rate limit exceeded for 86400 second(s) period for key"
+            }
+          ]
+        end
+
+        it 'returns an array of errors' do
+          result = error_formatter.to_array
+          expect(result).to eq(expected_result)
+        end
       end
 
-      it 'returns an array of errors' do
-        result = error_formatter.to_array
-        expect(result).to eq(expected_result)
+      context 'when response comes from API Gateway' do
+        let(:error_response) do
+          { 'message' => 'API rate limit exceeded' }
+        end
+
+        let(:expected_result) do
+          [
+            {
+              'error_type' => 'TOO_MANY_REQUESTS',
+              'error_message' => 'API rate limit exceeded'
+            }
+          ]
+        end
+
+        it 'returns an array of errors' do
+          result = error_formatter.to_array
+          expect(result).to eq(expected_result)
+        end
       end
     end
   end

--- a/spec/lib/rdstation/error/formatter_spec.rb
+++ b/spec/lib/rdstation/error/formatter_spec.rb
@@ -234,7 +234,8 @@ RSpec.describe RDStation::Error::Formatter do
           [
             {
               'error_type' => 'TOO_MANY_REQUESTS',
-              'error_message' => "'lead_limiter' rate limit exceeded for 86400 second(s) period for key"
+              'error_message' => "'lead_limiter' rate limit exceeded for 86400 second(s) period for key",
+              'details' => { 'max' => 24, 'usage' => 55, 'remaining_time' => 20745 }
             }
           ]
         end
@@ -246,15 +247,23 @@ RSpec.describe RDStation::Error::Formatter do
       end
 
       context 'when response comes from API Gateway' do
+        let(:error_formatter) { described_class.new(error_response, response_headers) }
         let(:error_response) do
           { 'message' => 'API rate limit exceeded' }
+        end
+        let(:response_headers) do
+          {
+            'ratelimit-limit-quotas' => 120,
+            'retry-after-quotas' => 20745
+          }
         end
 
         let(:expected_result) do
           [
             {
               'error_type' => 'TOO_MANY_REQUESTS',
-              'error_message' => 'API rate limit exceeded'
+              'error_message' => 'API rate limit exceeded',
+              'details' => { max: 120, usage: 120, remaining_time: 20745 }
             }
           ]
         end


### PR DESCRIPTION
### Problem

Exists two different error formats when a TooManyRequests (429) happen:

- RDSM format:
```
{
    "error": "'lead_limiter' rate limit exceeded for 86400 second(s) period for key 'lead@example.org'",
    "max": 24,
    "usage": 25,
    "remaining_time": 43067
}
```
- API Gateway format
```
{
    "message": "API rate limit exceeded"
}
```

### What was done

- Also handle TooManyRequests format from API Gateway

### How to test?

#### Adding gem on your project

1. Clone [the repository](https://github.com/Hilderlan/rdstation-ruby-client) in the same directory of the project you want to use rdstation-ruby-client gem
2. In the Gemfile, put `gem 'rdstation-ruby-client', path: '/var/rdstation-ruby-client'`
3. If you're using docker-compose, add a volume to make sure the path to the local gem will exist:
 ```
volumes:
            (...)
            - ../rdstation-ruby-client:/var/rdstation-ruby-client
            (...)
```
4. Access the console of your application and follow the steps below

#### Making a request with an invalid token

1. Follow the [instructions](https://github.com/ResultadosDigitais/rdstation-ruby-client#getting-access_token) described in the readme to generate an `access_token` on your project
5. Define a client with: `client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')`
6. Call one of the APIs supported through [API Gateway](https://github.com/ResultadosDigitais/api-gateway) until exceed its rate-limit defined [here](https://developers.rdstation.com/reference/limite-de-requisicoes-da-api)
7. When the rate-limit happen, the client won't crash anymore ([Rollbar](https://app.rollbar.com/a/ResultadosDigitais/fix/item/PlugCRM/34138/))

Running tests

1. `bundle install`
2. Run the tests with `bundle exec rspec spec/lib/rdstation/error`