### PR TITLE
Adiciona Pull Request templates para PRs em geral e hotfixes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/rdsm-ruby-client-pull-request-fix-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/rdsm-ruby-client-pull-request-fix-template.md
@@ -1,0 +1,34 @@
+# Description
+
+## Error
+
+<!-- In here try to describe the error that is happening that require this fix.
+Try to use less of this => "There is a nil variable that breaks a method, etc..."
+Try to use more of this => "In some cases it was not possible to complete the request..." -->
+
+## Cause
+
+<!-- In here try to describe what's the situation that led to error of this fix.
+Example: "It's not possible to make the request without the headers..." -->
+
+## Solution
+
+<!-- In here you can be more technical, for some solution can only be explain in that way.
+Example: "Adds a default header for when the user does not give one..." -->
+
+## Tests
+
+- [ ] Automated;
+<!-- In here you have to check if you are creating automated tests alongside the fix (Required). -->
+
+- [ ] Manual.
+<!-- In here you have to check if you made some manual testing after the fix.
+If possible, give more information about the manual tests that were made,
+which classes, methods, etc. that were tested. -->
+
+## Observations
+
+<!-- In here put any information that you believe is relevant for the understanding or follow up.
+Also, this is where you relate a issue with "Resolves #1000" -->
+
+<!-- Learn how to write a great PR description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

--- a/.github/PULL_REQUEST_TEMPLATE/rdsm-ruby-client-pull-request-general-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/rdsm-ruby-client-pull-request-general-template.md
@@ -1,0 +1,34 @@
+# Description
+
+## What
+
+<!-- Make a quick description on what this change is about. What is it for?
+What does it solve? Mention if it's part of a bigger project.
+Try not to be too technical in this part, leave the technicality to the "How?" session below. -->
+
+## Why?
+
+<!-- In here explain why this is necessary. What happened that lead the code to need this?
+Try not to be too technical in this part, too. Describe the motive behind the feature ou change. -->
+
+## How?
+
+<!-- In here it's ok to be technical. Describe briefly what changes were necessary in the code.
+Which classes were changed? What methods were added? What architecture was used? And so on... -->
+
+## Tests
+
+- [ ] Automated;
+<!-- In here you have to check if you are creating automated tests alongside the fix (Required). -->
+
+- [ ] Manual.
+<!-- In here you have to check if you made some manual testing after the fix.
+If possible, give more information about the manual tests that were made,
+which classes, methods, etc. that were tested. -->
+
+## Observations
+
+<!-- In here put any information that you believe is relevant for the understanding or follow up.
+Also, this is where you relate a issue with "Resolves #1000" -->
+
+<!-- Learn how to write a great PR description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->


### PR DESCRIPTION
# Description

## What?

Este PR adiciona dois templates para pull requests, um para PRs em geral e outro para correções.

## Why?

Para padronizar a descrição de Pull Requests.

## How?

Criando uma pasta PULL_REQUEST_TEMPLATE dentro de `.github` e criando dois modelos de pull requests dentro dela

## Tests

- [ ] ~Automated~; Não se aplica.
- [ ] ~Manual~. Não se aplica.
