### PR TITLE
[CRMCRUJ-2753] feat: add by_phone and by_identifier methods on contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 2.10.0
+
+### Additions
+
+#### 1. Getting a Contact by Phone
+
+Returns data about a specific Contact
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.contacts.by_phone('phone')
+```
+
+#### 2. Getting a Contact by Identifier
+
+Returns data about a specific Contact
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.contacts.by_identifier('identifier_type', 'identifier_value')
+```
+
+
 ## 2.9.0
 
 ### Additions

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'ref
 client.contacts.by_phone('phone')
 ```
 
-More info:  TBD
+More info:  https://developers.rdstation.com/reference/get_platform-contacts-identifier-value
 
 #### Update a Contact by UUID
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ client.contacts.by_email('email')
 
 More info:  https://developers.rdstation.com/pt-BR/reference/contacts#methodGetDetailsuuid
 
+#### Getting a Contact by Phone
+
+Returns data about a specific Contact
+
+```ruby
+client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'refresh_token')
+client.contacts.by_phone('phone')
+```
+
+More info:  TBD
+
 #### Update a Contact by UUID
 
 Updates the properties of a Contact.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'ref
 client.contacts.by_uuid('uuid')
 ```
 
-More info: https://developers.rdstation.com/reference/get_platform-contacts-identifier-value
+More info: https://developers.rdstation.com/reference/get_platform-contacts-identifier-value-1
 
 #### Getting a Contact by Email
 
@@ -135,7 +135,7 @@ client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'ref
 client.contacts.by_email('email')
 ```
 
-More info:  https://developers.rdstation.com/pt-BR/reference/contacts#methodGetDetailsuuid
+More info:  https://developers.rdstation.com/reference/get_platform-contacts-identifier-value-1
 
 #### Getting a Contact by Phone
 
@@ -146,7 +146,7 @@ client = RDStation::Client.new(access_token: 'access_token', refresh_token: 'ref
 client.contacts.by_phone('phone')
 ```
 
-More info:  https://developers.rdstation.com/reference/get_platform-contacts-identifier-value
+More info:  https://developers.rdstation.com/reference/get_platform-contacts-identifier-value-1
 
 #### Update a Contact by UUID
 

--- a/lib/rdstation/contacts.rb
+++ b/lib/rdstation/contacts.rb
@@ -16,8 +16,7 @@ module RDStation
     #   The value of the identifier
     #
     def by_identifier(identifier_type, identifier_value)
-      raise ArgumentError, "Invalid identifier type: #{identifier_type}" unless valid_identifier_type?(identifier_type)
-      raise ArgumentError, 'identifier_value cannot be nil or empty' if identifier_value.nil? || identifier_value.to_s.empty?
+      validate_by_identifier_args!(identifier_type, identifier_value)
 
       retryable_request(@authorization) do |authorization|
         path = build_identifier_path(identifier_type, identifier_value)
@@ -73,6 +72,16 @@ module RDStation
     end
 
     private
+
+    def validate_by_identifier_args!(identifier_type, identifier_value)
+      unless valid_identifier_type?(identifier_type)
+        raise ArgumentError, "Invalid identifier type: #{identifier_type}"
+      end
+
+      if identifier_value.nil? || identifier_value.to_s.empty?
+        raise ArgumentError, 'identifier_value cannot be nil or empty'
+      end
+    end
 
     def valid_identifier_type?(type)
       %i[uuid email phone].include?(type)

--- a/lib/rdstation/contacts.rb
+++ b/lib/rdstation/contacts.rb
@@ -78,11 +78,12 @@ module RDStation
     end
 
     def build_identifier_path(identifier_type, identifier_value)
+      encoded_value = URI.encode_www_form_component(identifier_value.to_s)
       case identifier_type
       when :uuid
-        identifier_value
+        encoded_value
       when :email, :phone
-        "#{identifier_type}:#{identifier_value}"
+        "#{identifier_type}:#{encoded_value}"
       end
     end
 

--- a/lib/rdstation/contacts.rb
+++ b/lib/rdstation/contacts.rb
@@ -17,6 +17,7 @@ module RDStation
     #
     def by_identifier(identifier_type, identifier_value)
       raise ArgumentError, "Invalid identifier type: #{identifier_type}" unless valid_identifier_type?(identifier_type)
+      raise ArgumentError, 'identifier_value cannot be nil or empty' if identifier_value.nil? || identifier_value.to_s.empty?
 
       retryable_request(@authorization) do |authorization|
         path = build_identifier_path(identifier_type, identifier_value)

--- a/lib/rdstation/contacts.rb
+++ b/lib/rdstation/contacts.rb
@@ -10,21 +10,31 @@ module RDStation
     end
 
     #
-    # param uuid:
-    #   The unique uuid associated to each RD Station Contact.
+    # param identifier_type:
+    #   The type of identifier: :uuid, :email, or :phone
+    # param identifier_value:
+    #   The value of the identifier
     #
-    def by_uuid(uuid)
+    def by_identifier(identifier_type, identifier_value)
+      raise ArgumentError, "Invalid identifier type: #{identifier_type}" unless valid_identifier_type?(identifier_type)
+
       retryable_request(@authorization) do |authorization|
-        response = self.class.get(base_url(uuid), headers: authorization.headers)
+        path = build_identifier_path(identifier_type, identifier_value)
+        response = self.class.get(base_url(path), headers: authorization.headers)
         ApiResponse.build(response)
       end
     end
 
+    def by_uuid(uuid)
+      by_identifier(:uuid, uuid)
+    end
+
     def by_email(email)
-      retryable_request(@authorization) do |authorization|
-        response = self.class.get(base_url("email:#{email}"), headers: authorization.headers)
-        ApiResponse.build(response)
-      end
+      by_identifier(:email, email)
+    end
+
+    def by_phone(phone)
+      by_identifier(:phone, phone)
     end
 
     # The Contact hash may contain the following parameters:
@@ -62,6 +72,19 @@ module RDStation
     end
 
     private
+
+    def valid_identifier_type?(type)
+      %i[uuid email phone].include?(type)
+    end
+
+    def build_identifier_path(identifier_type, identifier_value)
+      case identifier_type
+      when :uuid
+        identifier_value
+      when :email, :phone
+        "#{identifier_type}:#{identifier_value}"
+      end
+    end
 
     def base_url(path = '')
       "#{RDStation.host}/platform/contacts/#{path}"

--- a/lib/rdstation/version.rb
+++ b/lib/rdstation/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RDStation
-  VERSION = '2.9.0'
+  VERSION = '2.10.0'
 end

--- a/spec/lib/rdstation/contacts_spec.rb
+++ b/spec/lib/rdstation/contacts_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe RDStation::Contacts do
   let(:invalid_uuid) { 'invalid_uuid' }
   let(:valid_email) { 'valid@email.com' }
   let(:invalid_email) { 'invalid@email.com' }
+  let(:special_chars_email) { 'valid+user@example.com' }
   let(:valid_phone) { '11999999999' }
   let(:invalid_phone) { '11888888888' }
 
@@ -12,6 +13,10 @@ RSpec.describe RDStation::Contacts do
   let(:endpoint_with_invalid_uuid) { "https://api.rd.services/platform/contacts/#{invalid_uuid}" }
   let(:endpoint_with_valid_email) { "https://api.rd.services/platform/contacts/email:#{valid_email}" }
   let(:endpoint_with_invalid_email) { "https://api.rd.services/platform/contacts/email:#{invalid_email}" }
+  let(:endpoint_with_special_chars_email) do
+    encoded_email = URI.encode_www_form_component(special_chars_email)
+    "https://api.rd.services/platform/contacts/email:#{encoded_email}"
+  end
   let(:endpoint_with_valid_phone) { "https://api.rd.services/platform/contacts/phone:#{valid_phone}" }
   let(:endpoint_with_invalid_phone) { "https://api.rd.services/platform/contacts/phone:#{invalid_phone}" }
 
@@ -178,6 +183,24 @@ RSpec.describe RDStation::Contacts do
           end.to raise_error(RDStation::Error::ExpiredAccessToken)
         end
       end
+
+      describe 'with non-string identifier_value' do
+        let(:numeric_uuid) { 123 }
+        let(:endpoint_with_numeric_uuid) do
+          "https://api.rd.services/platform/contacts/#{numeric_uuid}"
+        end
+
+        before do
+          stub_request(:get, endpoint_with_numeric_uuid)
+            .with(headers: valid_headers)
+            .to_return(status: 200, body: {}.to_json)
+        end
+
+        it 'converts identifier_value to string before building the path' do
+          response = contact_with_valid_token.by_identifier(:uuid, numeric_uuid)
+          expect(response).to eq({})
+        end
+      end
     end
 
     describe 'with identifier_type :email' do
@@ -244,6 +267,23 @@ RSpec.describe RDStation::Contacts do
           expect do
             contact_with_expired_token.by_identifier(:email, valid_email)
           end.to raise_error(RDStation::Error::ExpiredAccessToken)
+        end
+      end
+
+      context 'when the email contains characters that must be URL encoded' do
+        let(:contact) do
+          { 'name' => 'Lead', 'email' => special_chars_email }
+        end
+
+        before do
+          stub_request(:get, endpoint_with_special_chars_email)
+            .with(headers: valid_headers)
+            .to_return(status: 200, body: contact.to_json)
+        end
+
+        it 'encodes identifier_value in the request path' do
+          response = contact_with_valid_token.by_identifier(:email, special_chars_email)
+          expect(response).to eq(contact)
         end
       end
     end
@@ -321,6 +361,20 @@ RSpec.describe RDStation::Contacts do
         expect do
           contact_with_valid_token.by_identifier(:invalid, 'some_value')
         end.to raise_error(ArgumentError, /Invalid identifier type/)
+      end
+    end
+
+    describe 'with invalid identifier_value' do
+      it 'raises ArgumentError when identifier_value is nil' do
+        expect do
+          contact_with_valid_token.by_identifier(:email, nil)
+        end.to raise_error(ArgumentError, /identifier_value cannot be nil or empty/)
+      end
+
+      it 'raises ArgumentError when identifier_value is an empty string' do
+        expect do
+          contact_with_valid_token.by_identifier(:email, '')
+        end.to raise_error(ArgumentError, /identifier_value cannot be nil or empty/)
       end
     end
   end

--- a/spec/lib/rdstation/contacts_spec.rb
+++ b/spec/lib/rdstation/contacts_spec.rb
@@ -539,7 +539,7 @@ RSpec.describe RDStation::Contacts do
           .to_return(expired_token_response)
       end
 
-      it 'raises a expired token error' do
+      it 'raises an expired token error' do
         expect do
           contact_with_expired_token.upsert('email', valid_email, {})
         end.to raise_error(RDStation::Error::ExpiredAccessToken)

--- a/spec/lib/rdstation/contacts_spec.rb
+++ b/spec/lib/rdstation/contacts_spec.rb
@@ -5,11 +5,15 @@ RSpec.describe RDStation::Contacts do
   let(:invalid_uuid) { 'invalid_uuid' }
   let(:valid_email) { 'valid@email.com' }
   let(:invalid_email) { 'invalid@email.com' }
+  let(:valid_phone) { '11999999999' }
+  let(:invalid_phone) { '11888888888' }
 
   let(:endpoint_with_valid_uuid) { "https://api.rd.services/platform/contacts/#{valid_uuid}" }
   let(:endpoint_with_invalid_uuid) { "https://api.rd.services/platform/contacts/#{invalid_uuid}" }
   let(:endpoint_with_valid_email) { "https://api.rd.services/platform/contacts/email:#{valid_email}" }
   let(:endpoint_with_invalid_email) { "https://api.rd.services/platform/contacts/email:#{invalid_email}" }
+  let(:endpoint_with_valid_phone) { "https://api.rd.services/platform/contacts/phone:#{valid_phone}" }
+  let(:endpoint_with_invalid_phone) { "https://api.rd.services/platform/contacts/phone:#{invalid_phone}" }
 
   let(:valid_access_token) { 'valid_access_token' }
   let(:invalid_access_token) { 'invalid_access_token' }
@@ -24,7 +28,6 @@ RSpec.describe RDStation::Contacts do
   let(:contact_with_invalid_token) do
     described_class.new(authorization: RDStation::Authorization.new(access_token: invalid_access_token))
   end
-
 
   let(:valid_headers) do
     {
@@ -108,139 +111,238 @@ RSpec.describe RDStation::Contacts do
     }
   end
 
-  describe '#by_uuid' do
-    it 'calls retryable_request' do
-      expect(contact_with_valid_token).to receive(:retryable_request)
-      contact_with_valid_token.by_uuid('valid_uuid')
-    end
+  describe '#by_identifier' do
+    describe 'with identifier_type :uuid' do
+      it 'calls retryable_request' do
+        expect(contact_with_valid_token).to receive(:retryable_request)
+        contact_with_valid_token.by_identifier(:uuid, valid_uuid)
+      end
 
-    context 'with a valid auth token' do
-      context 'when the contact exists' do
-        let(:contact) do
-          { 'name' => 'Lead', 'email' => 'valid@email.com' }
+      context 'with a valid auth token' do
+        context 'when the contact exists' do
+          let(:contact) do
+            { 'name' => 'Lead', 'email' => 'valid@email.com' }
+          end
+
+          before do
+            stub_request(:get, endpoint_with_valid_uuid)
+              .with(headers: valid_headers)
+              .to_return(status: 200, body: contact.to_json)
+          end
+
+          it 'returns the contact' do
+            response = contact_with_valid_token.by_identifier(:uuid, valid_uuid)
+            expect(response).to eq(contact)
+          end
         end
 
+        context 'when the contact does not exist' do
+          before do
+            stub_request(:get, endpoint_with_invalid_uuid)
+              .with(headers: valid_headers)
+              .to_return(not_found_response)
+          end
+
+          it 'raises a not found error' do
+            expect do
+              contact_with_valid_token.by_identifier(:uuid, invalid_uuid)
+            end.to raise_error(RDStation::Error::NotFound)
+          end
+        end
+      end
+
+      context 'with an invalid auth token' do
         before do
           stub_request(:get, endpoint_with_valid_uuid)
-            .with(headers: valid_headers)
-            .to_return(status: 200, body: contact.to_json)
+            .with(headers: invalid_token_headers)
+            .to_return(invalid_token_response)
         end
 
-        it 'returns the contact' do
-          response = contact_with_valid_token.by_uuid('valid_uuid')
-          expect(response).to eq(contact)
-        end
-      end
-
-      context 'when the contact does not exist' do
-        before do
-          stub_request(:get, endpoint_with_invalid_uuid)
-            .with(headers: valid_headers)
-            .to_return(not_found_response)
-        end
-
-        it 'raises a not found error' do
+        it 'raises an invalid token error' do
           expect do
-            contact_with_valid_token.by_uuid(invalid_uuid)
-          end.to raise_error(RDStation::Error::NotFound)
+            contact_with_invalid_token.by_identifier(:uuid, valid_uuid)
+          end.to raise_error(RDStation::Error::Unauthorized)
+        end
+      end
+
+      context 'with an expired auth token' do
+        before do
+          stub_request(:get, endpoint_with_valid_uuid)
+            .with(headers: expired_token_headers)
+            .to_return(expired_token_response)
+        end
+
+        it 'raises a expired token error' do
+          expect do
+            contact_with_expired_token.by_identifier(:uuid, valid_uuid)
+          end.to raise_error(RDStation::Error::ExpiredAccessToken)
         end
       end
     end
 
-    context 'with an invalid auth token' do
-      before do
-        stub_request(:get, endpoint_with_valid_uuid)
-          .with(headers: invalid_token_headers)
-          .to_return(invalid_token_response)
+    describe 'with identifier_type :email' do
+      it 'calls retryable_request' do
+        expect(contact_with_valid_token).to receive(:retryable_request)
+        contact_with_valid_token.by_identifier(:email, valid_email)
       end
 
-      it 'raises an invalid token error' do
-        expect do
-          contact_with_invalid_token.by_uuid(valid_uuid)
-        end.to raise_error(RDStation::Error::Unauthorized)
+      context 'with a valid auth token' do
+        context 'when the contact exists' do
+          let(:contact) do
+            { 'name' => 'Lead', 'email' => 'valid@email.com' }
+          end
+
+          before do
+            stub_request(:get, endpoint_with_valid_email)
+              .with(headers: valid_headers)
+              .to_return(status: 200, body: contact.to_json)
+          end
+
+          it 'returns the contact' do
+            response = contact_with_valid_token.by_identifier(:email, valid_email)
+            expect(response).to eq(contact)
+          end
+        end
+
+        context 'when the contact does not exist' do
+          before do
+            stub_request(:get, endpoint_with_invalid_email)
+              .with(headers: valid_headers)
+              .to_return(not_found_response)
+          end
+
+          it 'raises a not found error' do
+            expect do
+              contact_with_valid_token.by_identifier(:email, invalid_email)
+            end.to raise_error(RDStation::Error::NotFound)
+          end
+        end
+      end
+
+      context 'with an invalid auth token' do
+        before do
+          stub_request(:get, endpoint_with_valid_email)
+            .with(headers: invalid_token_headers)
+            .to_return(invalid_token_response)
+        end
+
+        it 'raises an invalid token error' do
+          expect do
+            contact_with_invalid_token.by_identifier(:email, valid_email)
+          end.to raise_error(RDStation::Error::Unauthorized)
+        end
+      end
+
+      context 'with an expired auth token' do
+        before do
+          stub_request(:get, endpoint_with_valid_email)
+            .with(headers: expired_token_headers)
+            .to_return(expired_token_response)
+        end
+
+        it 'raises a expired token error' do
+          expect do
+            contact_with_expired_token.by_identifier(:email, valid_email)
+          end.to raise_error(RDStation::Error::ExpiredAccessToken)
+        end
       end
     end
 
-    context 'with an expired auth token' do
-      before do
-        stub_request(:get, endpoint_with_valid_uuid)
-          .with(headers: expired_token_headers)
-          .to_return(expired_token_response)
+    describe 'with identifier_type :phone' do
+      it 'calls retryable_request' do
+        expect(contact_with_valid_token).to receive(:retryable_request)
+        contact_with_valid_token.by_identifier(:phone, valid_phone)
       end
 
-      it 'raises a expired token error' do
+      context 'with a valid auth token' do
+        context 'when the contact exists' do
+          let(:contact) do
+            { 'name' => 'Lead', 'phone' => valid_phone }
+          end
+
+          before do
+            stub_request(:get, endpoint_with_valid_phone)
+              .with(headers: valid_headers)
+              .to_return(status: 200, body: contact.to_json)
+          end
+
+          it 'returns the contact' do
+            response = contact_with_valid_token.by_identifier(:phone, valid_phone)
+            expect(response).to eq(contact)
+          end
+        end
+
+        context 'when the contact does not exist' do
+          before do
+            stub_request(:get, endpoint_with_invalid_phone)
+              .with(headers: valid_headers)
+              .to_return(not_found_response)
+          end
+
+          it 'raises a not found error' do
+            expect do
+              contact_with_valid_token.by_identifier(:phone, invalid_phone)
+            end.to raise_error(RDStation::Error::NotFound)
+          end
+        end
+      end
+
+      context 'with an invalid auth token' do
+        before do
+          stub_request(:get, endpoint_with_valid_phone)
+            .with(headers: invalid_token_headers)
+            .to_return(invalid_token_response)
+        end
+
+        it 'raises an invalid token error' do
+          expect do
+            contact_with_invalid_token.by_identifier(:phone, valid_phone)
+          end.to raise_error(RDStation::Error::Unauthorized)
+        end
+      end
+
+      context 'with an expired auth token' do
+        before do
+          stub_request(:get, endpoint_with_valid_phone)
+            .with(headers: expired_token_headers)
+            .to_return(expired_token_response)
+        end
+
+        it 'raises a expired token error' do
+          expect do
+            contact_with_expired_token.by_identifier(:phone, valid_phone)
+          end.to raise_error(RDStation::Error::ExpiredAccessToken)
+        end
+      end
+    end
+
+    describe 'with invalid identifier_type' do
+      it 'raises an ArgumentError' do
         expect do
-          contact_with_expired_token.by_uuid(valid_uuid)
-        end.to raise_error(RDStation::Error::ExpiredAccessToken)
+          contact_with_valid_token.by_identifier(:invalid, 'some_value')
+        end.to raise_error(ArgumentError, /Invalid identifier type/)
       end
     end
   end
 
+  describe '#by_uuid' do
+    it 'delegates to by_identifier with :uuid' do
+      expect(contact_with_valid_token).to receive(:by_identifier).with(:uuid, valid_uuid)
+      contact_with_valid_token.by_uuid(valid_uuid)
+    end
+  end
+
   describe '#by_email' do
-    it 'calls retryable_request' do
-      expect(contact_with_valid_token).to receive(:retryable_request)
-      contact_with_valid_token.by_email('x@xpto.com')
+    it 'delegates to by_identifier with :email' do
+      expect(contact_with_valid_token).to receive(:by_identifier).with(:email, valid_email)
+      contact_with_valid_token.by_email(valid_email)
     end
+  end
 
-    context 'with a valid auth token' do
-      context 'when the contact exists' do
-        let(:contact) do
-          { 'name' => 'Lead', 'email' => 'valid@email.com' }
-        end
-
-        before do
-          stub_request(:get, endpoint_with_valid_email)
-            .with(headers: valid_headers)
-            .to_return(status: 200, body: contact.to_json)
-        end
-
-        it 'returns the contact' do
-          response = contact_with_valid_token.by_email(valid_email)
-          expect(response).to eq(contact)
-        end
-      end
-
-      context 'when the contact does not exist' do
-        before do
-          stub_request(:get, endpoint_with_invalid_email)
-            .with(headers: valid_headers)
-            .to_return(not_found_response)
-        end
-
-        it 'raises a not found error' do
-          expect do
-            contact_with_valid_token.by_email(invalid_email)
-          end.to raise_error(RDStation::Error::NotFound)
-        end
-      end
-    end
-
-    context 'with an invalid auth token' do
-      before do
-        stub_request(:get, endpoint_with_valid_email)
-          .with(headers: invalid_token_headers)
-          .to_return(invalid_token_response)
-      end
-
-      it 'raises an invalid token error' do
-        expect do
-          contact_with_invalid_token.by_email(valid_email)
-        end.to raise_error(RDStation::Error::Unauthorized)
-      end
-    end
-
-    context 'with an expired auth token' do
-      before do
-        stub_request(:get, endpoint_with_valid_email)
-          .with(headers: expired_token_headers)
-          .to_return(expired_token_response)
-      end
-
-      it 'raises a expired token error' do
-        expect do
-          contact_with_expired_token.by_email(valid_email)
-        end.to raise_error(RDStation::Error::ExpiredAccessToken)
-      end
+  describe '#by_phone' do
+    it 'delegates to by_identifier with :phone' do
+      expect(contact_with_valid_token).to receive(:by_identifier).with(:phone, valid_phone)
+      contact_with_valid_token.by_phone(valid_phone)
     end
   end
 
@@ -437,7 +539,7 @@ RSpec.describe RDStation::Contacts do
           .to_return(expired_token_response)
       end
 
-      it 'raises an expired token error' do
+      it 'raises a expired token error' do
         expect do
           contact_with_expired_token.upsert('email', valid_email, {})
         end.to raise_error(RDStation::Error::ExpiredAccessToken)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 require 'rdstation-ruby-client'
 require 'webmock/rspec'
+require 'uri'


### PR DESCRIPTION
# Description

## What?

Este PR adiciona suporte para busca de contatos por telefone na gem rdstation-ruby-client, implementando um novo método genérico `by_identifier` que unifica a lógica de busca por diferentes tipos de identificador (`uuid`, `email` e `phone`), reduzindo duplicação de código, melhorando a manutenibilidade e mantendo a retrocompatibilidade.

## Why?

A gem rdstation-ruby-client precisava de uma interface para consultar contatos através do telefone. Ao invés de apenas duplicar o padrão dos métodos `by_uuid` e `by_email` com um novo `by_phone`, identificamos que todos os três métodos compartilham o mesmo fluxo, diferindo apenas na formatação do identificador.

Mais detalhes podem ser consultados no card: [CRMCRUJ-2753](https://rdstation.atlassian.net/browse/CRMCRUJ-2753)

## How?

### Adições

Novo método genérico `by_identifier(identifier_type, identifier_value)` que:
 - Aceita tipos de identificador: `:uuid`, `:email`, `:phone`
 - Valida o tipo de identificador
 - Formata corretamente a URL conforme o tipo
 - Executa a requisição GET com tratamento de retry

### Refatoração

 - Métodos `by_uuid`, `by_email` e `by_phone` agora delegam para `by_identifier`
 -  Método privado `build_identifier_path` encapsula a lógica de formatação
 -  Método privado `valid_identifier_type?` valida os tipos aceitos

## Tests

- Unitários
1. `bundle install`
2. Run the tests with `bundle exec rspec spec/lib/rdstation/contacts_spec.rb`

- Manual



[CRMCRUJ-2753]: https://rdstation.atlassian.net/browse/CRMCRUJ-2753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
 
 
 
 
 
 
 
 
 
 
 
 **PR Summary by Typo**
------------

#### Visão Geral
Este PR implementa a funcionalidade de buscar contatos por número de telefone e introduz um método genérico `by_identifier` para unificar a recuperação de contatos por UUID, e-mail ou telefone. Essa mudança refatora a lógica existente e expande as capacidades da gem `rdstation-ruby-client`, conforme solicitado na issue CRMCRUJ-2753.

#### Principais Mudanças
- Adicionados os métodos `by_phone` e `by_identifier` para buscar contatos por número de telefone e por um identificador genérico (UUID, e-mail ou telefone).
- Os métodos `by_uuid` e `by_email` existentes foram refatorados para delegar ao novo método `by_identifier`.
- Incluídas validações para os argumentos do método `by_identifier` para garantir tipos e valores válidos.
- A documentação em `CHANGELOG.md` e `README.md` foi atualizada para refletir as novas funcionalidades e a versão da gem foi atualizada para `2.10.0`.
- Adicionados testes abrangentes para cobrir o novo método `by_identifier` e suas delegações, incluindo cenários de URL encoding.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 232 (72.0%)   |
| Churn       | 7 (2.2%)      |
| Refactor    | 83 (25.8%)    |
| Total Changes | 322         |

#### Linked JIRA Issues
[CRMCRUJ-2753](https://rdstation.atlassian.net/browse/CRMCRUJ-2753) - Adiciona a funcionalidade de buscar contatos por telefone e refatora os métodos de busca por identificador na gem `rdstation-ruby-client`. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>